### PR TITLE
set env variables to execute commands

### DIFF
--- a/cmd/macadam/root.go
+++ b/cmd/macadam/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cfergeau/macadam/cmd/macadam/registry"
 	"github.com/cfergeau/macadam/pkg/cmdline"
+	"github.com/cfergeau/macadam/pkg/env"
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +53,7 @@ var (
 		TraverseChildren:      true,
 		Version:               cmdline.Version(),
 		DisableFlagsInUseLine: true,
+		PersistentPreRunE:     machinePreRunE,
 	}
 
 	// defaultLogLevel = "warn"
@@ -81,4 +83,8 @@ func Execute() {
 	}
 
 	os.Exit(registry.GetExitCode())
+}
+
+func machinePreRunE(c *cobra.Command, args []string) error {
+	return env.SetupEnvironment()
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 )
 
+require github.com/containers/storage v1.56.0
+
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
@@ -42,7 +44,6 @@ require (
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.2.0 // indirect
 	github.com/containers/psgo v1.9.0 // indirect
-	github.com/containers/storage v1.56.0 // indirect
 	github.com/containers/winquit v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09 // indirect
 	github.com/crc-org/vfkit v0.5.1 // indirect
@@ -179,6 +180,8 @@ require (
 	tags.cncf.io/container-device-interface v0.8.0 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20241127161353-592fb5161f59
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078
+
+replace github.com/containers/gvisor-tap-vsock => github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,12 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990 h1:NrYHaizZuMJX+7C/y5YS0PRDt1JFKRfsvEp0DBNQEuo=
+github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990/go.mod h1:gjdY4JBWnynrXsxT8+OM7peEOd4FCZpoOWjSadHva0g=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20241127161353-592fb5161f59 h1:ftTxlR1SCKLTyvJraZUVxO01+i9hvTVC3r7osaY5/HA=
-github.com/cfergeau/podman/v5 v5.0.0-20241127161353-592fb5161f59/go.mod h1:aSSwTYeD7i084QIiiTIFpolFyCP28H1h08AY22VrKIo=
+github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104 h1:QPRzqxScaJAsQc3qvprUeiO01FGPMxF5AQKP8D8Ez5o=
+github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104/go.mod h1:DTVzcjHg3KA5RwO36cd+nmJvfBPZKcfLugk7wL47ql0=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d h1:77cEq6EriyTZ0g/qfRdp61a3Uu/AWrgIq2s0ClJV1g0=
@@ -73,8 +75,6 @@ github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33 h1:Ih6KuyByK
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33/go.mod h1:RxIuKhwTpRl3ma4d4BF6QzSSeg9zNNvo/xhYJOKeDQs=
 github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0 h1:Vh8IytxprODmjd4sALcSVUzhT28vT537UWsfCXcahWk=
 github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0/go.mod h1:3mUU2/PxkOwvL46fmaRVj0YfBDBxNPOMctIvBHWo4Ak=
-github.com/containers/gvisor-tap-vsock v0.8.0 h1:Z8ZEWb+Lio0d+lXexONdUWT4rm9lF91vH0g3ARnMy7o=
-github.com/containers/gvisor-tap-vsock v0.8.0/go.mod h1:LVwnMiNvhxyGfhaMEQcXKJhNnN4h8woB9U3wf8rYOPc=
 github.com/containers/image/v5 v5.33.0 h1:6oPEFwTurf7pDTGw7TghqGs8K0+OvPtY/UyzU0B2DfE=
 github.com/containers/image/v5 v5.33.0/go.mod h1:T7HpASmvnp2H1u4cyckMvCzLuYgpD18dSmabSw0AcHk=
 github.com/containers/libhvee v0.9.0 h1:5UxJMka1lDfxTeITA25Pd8QVVttJAG43eQS1Getw1tc=

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,41 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/containers/storage/pkg/homedir"
+)
+
+const connectionsFile = "macadam-connections.json"
+
+func SetupEnvironment() error {
+	path, err := homedir.GetConfigHome()
+	if err != nil {
+		return err
+	}
+
+	connsFile := filepath.Join(filepath.Dir(path), "macadam", connectionsFile)
+	// set the path used for storing connection of macadam vms
+	err = os.Setenv("PODMAN_CONNECTIONS_CONF", connsFile)
+	if err != nil {
+		return err
+	}
+
+	// set the directory used when calculating the data and config paths
+	// config -> <configHome>/containers/macadam/machine (configHome changes based on the OS used e.g. configHome == /home/user/.config)
+	// data -> <dataHome>/containers/macadam/machine (dataHome changes based on the OS used e.g. dataHome == /home/user/.local/share)
+	err = os.Setenv("PODMAN_DATA_DIR", filepath.Join("macadam", "machine"))
+	if err != nil {
+		return err
+	}
+
+	// set the directory to be used when calculating runtime path
+	// run -> <runHome>/macadam (runHome changes based on the OS used e.g. runHome == /run)
+	err = os.Setenv("PODMAN_RUNTIME_DIR", "macadam")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/gvproxy_command.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/gvproxy_command.go
@@ -19,6 +19,9 @@ type GvproxyCommand struct {
 	// List of endpoints the user wants to listen to
 	endpoints []string
 
+	// List of service endpoints the user wants to listen to
+	servicesEndpoints []string
+
 	// Map of different sockets provided by user (socket-type flag:socket)
 	sockets map[string]string
 
@@ -60,6 +63,14 @@ func (c *GvproxyCommand) AddEndpoint(endpoint string) {
 	}
 
 	c.endpoints = append(c.endpoints, endpoint)
+}
+
+func (c *GvproxyCommand) AddServiceEndpoint(endpoint string) {
+	if len(c.servicesEndpoints) < 1 {
+		c.servicesEndpoints = []string{}
+	}
+
+	c.servicesEndpoints = append(c.servicesEndpoints, endpoint)
 }
 
 func (c *GvproxyCommand) AddVpnkitSocket(socket string) {
@@ -152,6 +163,18 @@ func (c *GvproxyCommand) endpointsToCmdline() []string {
 	return args
 }
 
+func (c *GvproxyCommand) servicesEndpointsToCmdline() []string {
+	args := []string{}
+
+	for _, endpoint := range c.servicesEndpoints {
+		if endpoint != "" {
+			args = append(args, "-services", endpoint)
+		}
+	}
+
+	return args
+}
+
 // ToCmdline converts Command to a properly formatted command for gvproxy based
 // on its fields
 func (c *GvproxyCommand) ToCmdline() []string {
@@ -159,6 +182,8 @@ func (c *GvproxyCommand) ToCmdline() []string {
 
 	// listen (endpoints)
 	args = append(args, c.endpointsToCmdline()...)
+
+	args = append(args, c.servicesEndpointsToCmdline()...)
 
 	// debug
 	if c.Debug {

--- a/vendor/github.com/containers/podman/v5/pkg/machine/env/dir.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/env/dir.go
@@ -56,7 +56,11 @@ func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
 		return nil, err
 	}
 
-	rtDir = filepath.Join(rtDir, "podman")
+	// The runtime directory can be customized using the PODMAN_RUNTIME_DIR env variable
+	// Its default value will be podman
+	// When used by macadam it can be customized to use a different path like macadam
+	runtimeDir := GetRuntimeDirSuffix()
+	rtDir = filepath.Join(rtDir, runtimeDir)
 	configDir, err := GetConfDir(vmType)
 	if err != nil {
 		return nil, err
@@ -109,12 +113,16 @@ func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
 }
 
 // DataDirPrefix returns the path prefix for all machine data files
+// The config directory can be customized using the PODMAN_DATA_DIR env variable
+// Its default value will be /podman/machine
+// When used by macadam it can be customized to use a different path like /macadam/machine
 func DataDirPrefix() (string, error) {
 	data, err := homedir.GetDataHome()
 	if err != nil {
 		return "", err
 	}
-	dataDir := filepath.Join(data, "containers", "podman", "machine")
+	machineDataDir := getDataDirSuffix()
+	dataDir := filepath.Join(data, "containers", machineDataDir)
 	return dataDir, nil
 }
 
@@ -134,12 +142,16 @@ func GetConfDir(vmType define.VMType) (string, error) {
 }
 
 // ConfDirPrefix returns the path prefix for all machine config files
+// The config directory can be customized using the PODMAN_DATA_DIR env variable
+// Its default value will be /podman/machine
+// When used by macadam it can be customized to use a different path like /macadam/machine
 func ConfDirPrefix() (string, error) {
 	conf, err := homedir.GetConfigHome()
 	if err != nil {
 		return "", err
 	}
-	confDir := filepath.Join(conf, "containers", "podman", "machine")
+	machineDataDir := getDataDirSuffix()
+	confDir := filepath.Join(conf, "containers", machineDataDir)
 	return confDir, nil
 }
 
@@ -157,4 +169,20 @@ func WithPodmanPrefix(name string) string {
 		name = "podman-" + name
 	}
 	return name
+}
+
+func getDataDirSuffix() string {
+	machineDir := os.Getenv("PODMAN_DATA_DIR")
+	if machineDir == "" {
+		machineDir = filepath.Join("podman", "machine")
+	}
+	return machineDir
+}
+
+func GetRuntimeDirSuffix() string {
+	runtimeDir := os.Getenv("PODMAN_RUNTIME_DIR")
+	if runtimeDir == "" {
+		runtimeDir = filepath.Join("podman")
+	}
+	return runtimeDir
 }

--- a/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking.go
@@ -69,6 +69,8 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 		cmd.AddForwardUser(forwardUser)
 		cmd.AddForwardIdentity(mc.SSH.IdentityPath)
 	}
+	serviceEndpoint := filepath.Join(runDir.GetPath(), "gv.sock")
+	cmd.AddServiceEndpoint(fmt.Sprintf("unix://%s", serviceEndpoint))
 
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmd.Debug = true

--- a/vendor/github.com/containers/podman/v5/pkg/util/utils_windows.go
+++ b/vendor/github.com/containers/podman/v5/pkg/util/utils_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/storage/pkg/homedir"
 )
 
@@ -35,7 +36,8 @@ func GetRootlessRuntimeDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	runtimeDir := filepath.Join(data, "containers", "podman")
+	rtDir := env.GetRuntimeDirSuffix()
+	runtimeDir := filepath.Join(data, "containers", rtDir)
 	return runtimeDir, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/containers/common/pkg/supplemented
 github.com/containers/common/pkg/timetype
 github.com/containers/common/pkg/util
 github.com/containers/common/version
-# github.com/containers/gvisor-tap-vsock v0.8.0
+# github.com/containers/gvisor-tap-vsock v0.8.0 => github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990
 ## explicit; go 1.22.0
 github.com/containers/gvisor-tap-vsock/pkg/types
 # github.com/containers/image/v5 v5.33.0
@@ -251,7 +251,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20241127161353-592fb5161f59
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
 ## explicit; go 1.22.6
 github.com/containers/podman/v5/libpod/define
 github.com/containers/podman/v5/pkg/errorhandling
@@ -1075,5 +1075,6 @@ gopkg.in/yaml.v3
 # tags.cncf.io/container-device-interface v0.8.0
 ## explicit; go 1.20
 tags.cncf.io/container-device-interface/pkg/parser
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20241127161353-592fb5161f59
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078
+# github.com/containers/gvisor-tap-vsock => github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990


### PR DESCRIPTION
before executing any action we need to update the environment variables PODMAN_CONNECTIONS_CONF, PODMAN_DATA_DIR and PODMAN_RUNTIME_DIR to define a specific location where to store macadam data. This way we prevent to write macadam stuff within podman-related folders

This works with https://github.com/cfergeau/podman/pull/1