### PR TITLE
Enable cloud-init to inject ssh key on applehv

### DIFF
--- a/cmd/macadam/init.go
+++ b/cmd/macadam/init.go
@@ -196,6 +196,7 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	initOpts.DiskSize = 50
 	initOpts.SSHIdentityPath = sshIdentityPath
 	initOpts.Username = username
+	initOpts.CloudInit = true // this should be calculated based on the image we want to start ??
 	/*
 		_, _, err = shim.VMExists(machineName, []vmconfigs.VMProvider{provider})
 		if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -178,6 +178,6 @@ require (
 	tags.cncf.io/container-device-interface v0.8.0 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250227172120-62a9ed627c8f
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104 h1:QPRzqxScaJAsQc3qvprUeiO01FGPMxF5AQKP8D8Ez5o=
-github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104/go.mod h1:DTVzcjHg3KA5RwO36cd+nmJvfBPZKcfLugk7wL47ql0=
+github.com/cfergeau/podman/v5 v5.0.0-20250227172120-62a9ed627c8f h1:I78jv8kRlBCV/5+lh3CKtP6mzu8QPFvVkP3twfGfV+A=
+github.com/cfergeau/podman/v5 v5.0.0-20250227172120-62a9ed627c8f/go.mod h1:DTVzcjHg3KA5RwO36cd+nmJvfBPZKcfLugk7wL47ql0=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=

--- a/pkg/imagepullers/noop.go
+++ b/pkg/imagepullers/noop.go
@@ -33,7 +33,7 @@ func (puller *NoopImagePuller) SetSourceURI(sourcePath string) {
 
 func imageExtension(sourceURI string) string {
 	if strings.HasSuffix(sourceURI, ".tar.gz") {
-		return "tar.gz"
+		return ".tar.gz"
 	}
 	return filepath.Ext(sourceURI)
 }
@@ -50,7 +50,7 @@ func (puller *NoopImagePuller) LocalPath() (*define.VMFile, error) {
 		return nil, err
 	}
 
-	vmFile, err := dirs.DataDir.AppendToNewVMFile(fmt.Sprintf("%s-%s.%s", puller.machineName, puller.vmType.String(), imageExtension(puller.sourceURI)), nil)
+	vmFile, err := dirs.DataDir.AppendToNewVMFile(fmt.Sprintf("%s-%s%s", puller.machineName, puller.vmType.String(), imageExtension(puller.sourceURI)), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/podman/v5/pkg/machine/cloudinit/cloudinit.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/cloudinit/cloudinit.go
@@ -1,0 +1,40 @@
+package cloudinit
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+type User struct {
+	Name    string   `yaml:"name"`
+	Sudo    string   `yaml:"sudo"`
+	Shell   string   `yaml:"shell"`
+	Groups  string   `yaml:"groups"`
+	SSHKeys []string `yaml:"ssh_authorized_keys"`
+}
+
+type UserData struct {
+	Users []User `yaml:"users"`
+}
+
+func GenerateUserData(dir string, data UserData) (string, error) {
+	yamlBytes, err := yaml.Marshal(&data)
+	if err != nil {
+		logrus.Errorf("Error marshaling to YAML: %v", err)
+		return "", err
+	}
+
+	headerLine := "#cloud-config\n"
+	yamlBytes = append([]byte(headerLine), yamlBytes...)
+
+	path := filepath.Join(dir, "user-data")
+	err = os.WriteFile(path, yamlBytes, 0644)
+	if err != nil {
+		logrus.Errorf("Error creating temp file: %v", err)
+		return "", err
+	}
+	return path, nil
+}

--- a/vendor/github.com/containers/podman/v5/pkg/machine/define/initopts.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/define/initopts.go
@@ -21,4 +21,5 @@ type InitOptions struct {
 	UserModeNetworking *bool  // nil = use backend/system default, false = disable, true = enable
 	USBs               []string
 	ImagePuller        ImagePuller
+	CloudInit          bool
 }

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config.go
@@ -53,6 +53,8 @@ type MachineConfig struct {
 	Starting bool
 
 	Rosetta bool
+
+	CloudInit bool
 }
 
 type machineImage interface { //nolint:unused

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine.go
@@ -96,6 +96,7 @@ func NewMachineConfig(opts define.InitOptions, dirs *define.MachineDirs, sshIden
 	mc.Created = time.Now()
 
 	mc.HostUser = HostUser{UID: getHostUID(), Rootful: opts.Rootful}
+	mc.CloudInit = opts.CloudInit
 
 	return mc, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -256,7 +256,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250227172120-62a9ed627c8f
 ## explicit; go 1.22.6
 github.com/containers/podman/v5/libpod/define
 github.com/containers/podman/v5/pkg/errorhandling
@@ -264,6 +264,7 @@ github.com/containers/podman/v5/pkg/machine
 github.com/containers/podman/v5/pkg/machine/apple
 github.com/containers/podman/v5/pkg/machine/apple/vfkit
 github.com/containers/podman/v5/pkg/machine/applehv
+github.com/containers/podman/v5/pkg/machine/cloudinit
 github.com/containers/podman/v5/pkg/machine/compression
 github.com/containers/podman/v5/pkg/machine/connection
 github.com/containers/podman/v5/pkg/machine/define
@@ -1091,5 +1092,5 @@ gopkg.in/yaml.v3
 # tags.cncf.io/container-device-interface v0.8.0
 ## explicit; go 1.20
 tags.cncf.io/container-device-interface/pkg/parser
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250227172120-62a9ed627c8f
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
with https://github.com/crc-org/vfkit/pull/263 and https://github.com/cfergeau/podman/pull/3 we can leverage cloud-init to inject ssh key into a rhel vm.
this patch allows to set the cloudinit flag from macadam that would define if the vm should be customized by using cloud-init or the default ignition.

This needs to be updated when https://github.com/cfergeau/podman/pull/3 is merged