### PR TITLE
build: Rename go module to github.com/crc-org/macadam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build check clean cross test
 
 GIT_VERSION ?= $(shell git describe --always --dirty)
-VERSION_LDFLAGS=-X github.com/cfergeau/macadam/pkg/cmdline.gitVersion=$(GIT_VERSION)
+VERSION_LDFLAGS=-X github.com/crc-org/macadam/pkg/cmdline.gitVersion=$(GIT_VERSION)
 # opengpg and btrfs support are used by github.com/containers/image and
 # github.com/containers/storage when container images are fetched.
 # These require external C libraries and their headers, it's simpler to disable

--- a/cmd/macadam/init.go
+++ b/cmd/macadam/init.go
@@ -5,9 +5,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/cfergeau/macadam/cmd/macadam/registry"
-	"github.com/cfergeau/macadam/pkg/imagepullers"
-	macadam "github.com/cfergeau/macadam/pkg/machinedriver"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	"github.com/crc-org/macadam/pkg/imagepullers"
+	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	"github.com/containers/common/pkg/completion"
 	ldefine "github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/machine/define"

--- a/cmd/macadam/list.go
+++ b/cmd/macadam/list.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cfergeau/macadam/cmd/macadam/registry"
-	macadam "github.com/cfergeau/macadam/pkg/machinedriver"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	"github.com/containers/common/pkg/completion"
 	"github.com/crc-org/machine/libmachine/state"
 	"github.com/spf13/cobra"

--- a/cmd/macadam/main.go
+++ b/cmd/macadam/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cfergeau/macadam/cmd/macadam/registry"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/macadam/rm.go
+++ b/cmd/macadam/rm.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/cfergeau/macadam/cmd/macadam/registry"
-	macadam "github.com/cfergeau/macadam/pkg/machinedriver"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/spf13/cobra"
 )

--- a/cmd/macadam/root.go
+++ b/cmd/macadam/root.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cfergeau/macadam/cmd/macadam/registry"
-	"github.com/cfergeau/macadam/pkg/cmdline"
-	"github.com/cfergeau/macadam/pkg/env"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	"github.com/crc-org/macadam/pkg/cmdline"
+	"github.com/crc-org/macadam/pkg/env"
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/spf13/cobra"
 )

--- a/cmd/macadam/start.go
+++ b/cmd/macadam/start.go
@@ -5,8 +5,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/cfergeau/macadam/cmd/macadam/registry"
-	macadam "github.com/cfergeau/macadam/pkg/machinedriver"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	ldefine "github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/provider"

--- a/cmd/macadam/stop.go
+++ b/cmd/macadam/stop.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/cfergeau/macadam/cmd/macadam/registry"
-	macadam "github.com/cfergeau/macadam/pkg/machinedriver"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/crc-org/macadam
 
-go 1.22.6
-
-toolchain go1.23.2
+go 1.23
 
 require (
 	github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cfergeau/macadam
+module github.com/crc-org/macadam
 
 go 1.22.6
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/containerd/typeurl/v2 v2.2.0 // indirect
 	github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33 // indirect
-	github.com/containers/gvisor-tap-vsock v0.8.3 // indirect
+	github.com/containers/gvisor-tap-vsock v0.8.4-0.20250227160003-36bc62c4d5be // indirect
 	github.com/containers/image/v5 v5.33.0 // indirect
 	github.com/containers/libhvee v0.9.0 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
@@ -183,5 +183,3 @@ require (
 replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078
-
-replace github.com/containers/gvisor-tap-vsock => github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990

--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,11 @@ toolchain go1.23.2
 require (
 	github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0
 	github.com/containers/podman/v5 v5.3.1
+	github.com/containers/storage v1.57.1
 	github.com/crc-org/crc/v2 v2.47.0
 	github.com/crc-org/machine v0.0.0-20240926103419-a943b47fd48b
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6 // indirect
 )
-
-require github.com/containers/storage v1.57.1
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
@@ -94,6 +91,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -145,6 +143,7 @@ require (
 	github.com/sigstore/rekor v1.3.6 // indirect
 	github.com/sigstore/sigstore v1.8.9 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
 	github.com/sylabs/sif/v2 v2.19.1 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990 h1:NrYHaizZuMJX+7C/y5YS0PRDt1JFKRfsvEp0DBNQEuo=
-github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990/go.mod h1:gjdY4JBWnynrXsxT8+OM7peEOd4FCZpoOWjSadHva0g=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
 github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104 h1:QPRzqxScaJAsQc3qvprUeiO01FGPMxF5AQKP8D8Ez5o=
@@ -72,6 +70,8 @@ github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33 h1:Ih6KuyByK
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33/go.mod h1:RxIuKhwTpRl3ma4d4BF6QzSSeg9zNNvo/xhYJOKeDQs=
 github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0 h1:Vh8IytxprODmjd4sALcSVUzhT28vT537UWsfCXcahWk=
 github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0/go.mod h1:3mUU2/PxkOwvL46fmaRVj0YfBDBxNPOMctIvBHWo4Ak=
+github.com/containers/gvisor-tap-vsock v0.8.4-0.20250227160003-36bc62c4d5be h1:/OVz49uNNL1dZsljxDn+scFbZv9GVYB5rzA8pMF5J4o=
+github.com/containers/gvisor-tap-vsock v0.8.4-0.20250227160003-36bc62c4d5be/go.mod h1:Guh8d/SiuJ9jlnuIyUjcKkFKQ2qpLhNKPGD1jMoIt2Q=
 github.com/containers/image/v5 v5.33.0 h1:6oPEFwTurf7pDTGw7TghqGs8K0+OvPtY/UyzU0B2DfE=
 github.com/containers/image/v5 v5.33.0/go.mod h1:T7HpASmvnp2H1u4cyckMvCzLuYgpD18dSmabSw0AcHk=
 github.com/containers/libhvee v0.9.0 h1:5UxJMka1lDfxTeITA25Pd8QVVttJAG43eQS1Getw1tc=

--- a/pkg/cmdline/version.go
+++ b/pkg/cmdline/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	// set using the '-X github.com/cfergeau/macadam/pkg/cmdline.gitVersion' linker flag
+	// set using the '-X github.com/crc-org/macadam/pkg/cmdline.gitVersion' linker flag
 	gitVersion = "unknown"
 
 	// set through .gitattributes when `git archive` is used

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,7 +161,7 @@ github.com/containers/common/pkg/supplemented
 github.com/containers/common/pkg/timetype
 github.com/containers/common/pkg/util
 github.com/containers/common/version
-# github.com/containers/gvisor-tap-vsock v0.8.3 => github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990
+# github.com/containers/gvisor-tap-vsock v0.8.4-0.20250227160003-36bc62c4d5be
 ## explicit; go 1.22.0
 github.com/containers/gvisor-tap-vsock/pkg/types
 # github.com/containers/image/v5 v5.33.0
@@ -1086,4 +1086,3 @@ gopkg.in/yaml.v3
 tags.cncf.io/container-device-interface/pkg/parser
 # github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250224120923-ac315765d104
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078
-# github.com/containers/gvisor-tap-vsock => github.com/cfergeau/gvisor-tap-vsock v0.7.3-0.20241209155656-dc16c2d91990


### PR DESCRIPTION
There are also some slight go.mod cleanups.