### PR TITLE
Update init help description

### DIFF
--- a/cmd/macadam/init.go
+++ b/cmd/macadam/init.go
@@ -18,12 +18,12 @@ import (
 
 var (
 	initCmd = &cobra.Command{
-		Use:               "init [options] [NAME]",
+		Use:               "init [options] [IMAGE]",
 		Short:             "Initialize a virtual machine",
 		Long:              "Initialize a virtual machine",
 		RunE:              initMachine,
 		Args:              cobra.MaximumNArgs(1),
-		Example:           `macadam init podman-machine-default`,
+		Example:           `macadam init image.raw`,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
 

--- a/cmd/macadam/init.go
+++ b/cmd/macadam/init.go
@@ -31,8 +31,6 @@ var (
 	// initOptionalFlags  = InitOptionalFlags{}
 	defaultMachineName = "macadam"
 	// now                bool
-	sshIdentityPath string
-	username        string
 )
 
 // Flags which have a meaning when unspecified that differs from the flag default
@@ -51,20 +49,16 @@ func init() {
 
 	flags := initCmd.Flags()
 
-	ImageFlagName := "image"
-	flags.StringVar(&initOptsFromFlags.Image, ImageFlagName, "", "Bootable image for machine")
-	_ = initCmd.RegisterFlagCompletionFunc(ImageFlagName, completion.AutocompleteDefault)
-
 	MachineNameFlagName := "machine-name"
 	flags.StringVar(&initOptsFromFlags.Name, MachineNameFlagName, defaultMachineName, "Name for the machine")
 	_ = initCmd.RegisterFlagCompletionFunc(MachineNameFlagName, completion.AutocompleteDefault)
 
 	SSHIdentityPathFlagName := "ssh-identity-path"
-	flags.StringVar(&sshIdentityPath, SSHIdentityPathFlagName, "", "Path to the SSH private key to use to access the machine")
+	flags.StringVar(&initOptsFromFlags.SSHIdentityPath, SSHIdentityPathFlagName, "", "Path to the SSH private key to use to access the machine")
 	_ = initCmd.RegisterFlagCompletionFunc(SSHIdentityPathFlagName, completion.AutocompleteDefault)
 
 	UsernameFlagName := "username"
-	flags.StringVar(&username, UsernameFlagName, "", "Username used in image")
+	flags.StringVar(&initOptsFromFlags.Username, UsernameFlagName, "", "Username used in image")
 	_ = initCmd.RegisterFlagCompletionFunc(UsernameFlagName, completion.AutocompleteDefault)
 
 	cpusFlagName := "cpus"
@@ -183,8 +177,8 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	initOpts.CPUS = initOptsFromFlags.CPUS
 	initOpts.DiskSize = initOptsFromFlags.DiskSize
 	initOpts.Memory = initOptsFromFlags.Memory
-	initOpts.SSHIdentityPath = sshIdentityPath
-	initOpts.Username = username
+	initOpts.SSHIdentityPath = initOptsFromFlags.SSHIdentityPath
+	initOpts.Username = initOptsFromFlags.Username
 	initOpts.CloudInit = true // this should be calculated based on the image we want to start ??
 	/*
 		_, _, err = shim.VMExists(machineName, []vmconfigs.VMProvider{provider})


### PR DESCRIPTION
This patch updates the help description of the init action by enhancing the `Use` and `Example` descriptions and removing the unused `--image` flag