### PR TITLE
update podman dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,6 +179,6 @@ require (
 	tags.cncf.io/container-device-interface v0.8.1 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250305125814-d4a42dba3373
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250305125814-d4a42dba3373 h1:lOPQMc7Ok1ANn2mBLodrTNK6IXPDr2deeREAmExiG+U=
-github.com/cfergeau/podman/v5 v5.0.0-20250305125814-d4a42dba3373/go.mod h1:IFzo7ohforx759kkElhbTkrv0+9W+8QfjdqbVTq2bcw=
+github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1 h1:hPNGs5f88cO4G47NR4WdTAt4u0PbU2y7s52NUyywBwU=
+github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1/go.mod h1:IFzo7ohforx759kkElhbTkrv0+9W+8QfjdqbVTq2bcw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=

--- a/vendor/github.com/containers/podman/v5/pkg/machine/gvproxy_unix.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/gvproxy_unix.go
@@ -64,7 +64,7 @@ func waitOnProcess(processID int) error {
 		return nil
 	}
 
-	if err := p.Kill(); err != nil {
+	if err := p.Terminate(); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
 			logrus.Debugf("Gvproxy already dead, exiting cleanly")
 			return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -256,7 +256,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250305125814-d4a42dba3373
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1
 ## explicit; go 1.22.8
 github.com/containers/podman/v5/libpod/define
 github.com/containers/podman/v5/pkg/errorhandling
@@ -1108,5 +1108,5 @@ gopkg.in/yaml.v3
 # tags.cncf.io/container-device-interface v0.8.1
 ## explicit; go 1.20
 tags.cncf.io/container-device-interface/pkg/parser
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250305125814-d4a42dba3373
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
it updates the podman dep to leverage the fix on how gvproxy is killed https://github.com/cfergeau/podman/pull/5 this fixes an issue that prevented to delete and recreate a macadam VM bc the socket was not deleted correctly

it resolves #86 