### PR TITLE
customize tool name for wsl dist registration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,6 +179,6 @@ require (
 	tags.cncf.io/container-device-interface v0.8.1 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1 h1:hPNGs5f88cO4G47NR4WdTAt4u0PbU2y7s52NUyywBwU=
-github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1/go.mod h1:IFzo7ohforx759kkElhbTkrv0+9W+8QfjdqbVTq2bcw=
+github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a h1:gmSGx5qMxAuAgi2S0ls95/9MzRLDmZVVhMExn6kVI9o=
+github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a/go.mod h1:IFzo7ohforx759kkElhbTkrv0+9W+8QfjdqbVTq2bcw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containers/podman/v5/pkg/machine/define"
+	provider2 "github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/storage/pkg/homedir"
 )
 
@@ -35,6 +37,20 @@ func SetupEnvironment() error {
 	err = os.Setenv("PODMAN_RUNTIME_DIR", "macadam")
 	if err != nil {
 		return err
+	}
+
+	provider, err := provider2.Get()
+	if err != nil {
+		return err
+	}
+
+	// set the prefix that will be used when creating the wsl distro
+	// if this is not set, every dist will have "podman" as prefix
+	if provider.VMType() == define.WSLVirt {
+		err = os.Setenv("PODMAN_TOOL_PREFIX", "macadam")
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/vendor/github.com/containers/podman/v5/pkg/machine/env/dir.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/env/dir.go
@@ -2,14 +2,24 @@ package env
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/homedir"
 )
+
+var getToolName = sync.OnceValue(func() string {
+	toolName := os.Getenv("PODMAN_TOOL_PREFIX")
+	if toolName == "" {
+		toolName = "podman"
+	}
+	return toolName
+})
 
 // GetCacheDir returns the dir where VM images are downloaded into when pulled
 func GetCacheDir(vmType define.VMType) (string, error) {
@@ -164,9 +174,10 @@ func GetSSHIdentityPath(name string) (string, error) {
 	return filepath.Join(datadir, name), nil
 }
 
-func WithPodmanPrefix(name string) string {
-	if !strings.HasPrefix(name, "podman") {
-		name = "podman-" + name
+func WithToolPrefix(name string) string {
+	toolName := getToolName()
+	if !strings.HasPrefix(name, toolName) {
+		name = fmt.Sprintf("%s-%s", toolName, name)
 	}
 	return name
 }

--- a/vendor/github.com/containers/podman/v5/pkg/machine/machine_windows.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/machine_windows.go
@@ -126,7 +126,7 @@ func LaunchWinProxy(opts WinProxyOpts, noInfo bool) {
 }
 
 func launchWinProxy(opts WinProxyOpts) (bool, string, error) {
-	machinePipe := env.WithPodmanPrefix(opts.Name)
+	machinePipe := env.WithToolPrefix(opts.Name)
 	if !PipeNameAvailable(machinePipe, MachineNameWait) {
 		return false, "", fmt.Errorf("could not start api proxy since expected pipe is not available: %s", machinePipe)
 	}

--- a/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking_windows.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking_windows.go
@@ -11,7 +11,7 @@ import (
 )
 
 func setupMachineSockets(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
-	machinePipe := env.WithPodmanPrefix(mc.Name)
+	machinePipe := env.WithToolPrefix(mc.Name)
 	if !machine.PipeNameAvailable(machinePipe, machine.MachineNameWait) {
 		return nil, "", 0, fmt.Errorf("could not start api proxy since expected pipe is not available: %s", machinePipe)
 	}

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine_windows.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine_windows.go
@@ -6,6 +6,6 @@ import (
 )
 
 func getPipe(name string) *define.VMFile {
-	pipeName := env.WithPodmanPrefix(name)
+	pipeName := env.WithToolPrefix(name)
 	return &define.VMFile{Path: `\\.\pipe\` + pipeName}
 }

--- a/vendor/github.com/containers/podman/v5/pkg/machine/wsl/machine.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/wsl/machine.go
@@ -61,7 +61,7 @@ func getConfigPathExt(name string, extension string) (string, error) {
 // TODO like provisionWSL, i think this needs to be pushed to use common
 // paths and types where possible
 func unprovisionWSL(mc *vmconfigs.MachineConfig) error {
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 	if err := terminateDist(dist); err != nil {
 		logrus.Error(err)
 	}
@@ -93,7 +93,7 @@ func provisionWSLDist(name string, imagePath string, prompt string) (string, err
 		return "", fmt.Errorf("could not create wsldist directory: %w", err)
 	}
 
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	fmt.Println(prompt)
 	if err = runCmdPassThrough(wutil.FindWSL(), "--import", dist, distTarget, imagePath, "--version", "2"); err != nil {
 		return "", fmt.Errorf("the WSL import of guest OS failed: %w", err)
@@ -726,7 +726,7 @@ func unregisterDist(dist string) error {
 }
 
 func isRunning(name string) (bool, error) {
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	wsl, err := isWSLRunning(dist)
 	if err != nil {
 		return false, err
@@ -761,7 +761,7 @@ func getDiskSize(name string) strongunits.GiB {
 
 //nolint:unused
 func getCPUs(name string) (uint64, error) {
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}
@@ -791,7 +791,7 @@ func getCPUs(name string) (uint64, error) {
 
 //nolint:unused
 func getMem(name string) (strongunits.MiB, error) {
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}

--- a/vendor/github.com/containers/podman/v5/pkg/machine/wsl/stubber.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/wsl/stubber.go
@@ -89,7 +89,7 @@ func (w WSLStubber) PrepareIgnition(_ *vmconfigs.MachineConfig, _ *ignition.Igni
 }
 
 func (w WSLStubber) Exists(name string) (bool, error) {
-	return isWSLExist(env.WithPodmanPrefix(name))
+	return isWSLExist(env.WithToolPrefix(name))
 }
 
 func (w WSLStubber) MountType() vmconfigs.VolumeMountType {
@@ -105,7 +105,7 @@ func (w WSLStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error,
 	// below if we wanted to hard error on the wsl unregister
 	// of the vm
 	wslRemoveFunc := func() error {
-		if err := runCmdPassThrough(wutil.FindWSL(), "--unregister", env.WithPodmanPrefix(mc.Name)); err != nil {
+		if err := runCmdPassThrough(wutil.FindWSL(), "--unregister", env.WithToolPrefix(mc.Name)); err != nil {
 			return err
 		}
 		return nil
@@ -154,7 +154,7 @@ func (w WSLStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.Se
 			return errors.New("user-mode networking can only be changed when the machine is not running")
 		}
 
-		dist := env.WithPodmanPrefix(mc.Name)
+		dist := env.WithToolPrefix(mc.Name)
 		if err := changeDistUserModeNetworking(dist, mc.SSH.RemoteUsername, mc.ImagePath.GetPath(), *opts.UserModeNetworking); err != nil {
 			return fmt.Errorf("failure changing state of user-mode networking setting: %w", err)
 		}
@@ -205,7 +205,7 @@ func (w WSLStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo bool
 }
 
 func (w WSLStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func() error, error) {
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 
 	err := wslInvoke(dist, "/root/bootstrap")
 	if err != nil {
@@ -239,7 +239,7 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 		return err
 	}
 
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 
 	// Stop user-mode networking if enabled
 	if err := stopUserModeNetworking(mc); err != nil {
@@ -277,7 +277,7 @@ func (w WSLStubber) StopHostNetworking(mc *vmconfigs.MachineConfig, vmType defin
 }
 
 func (w WSLStubber) UpdateSSHPort(mc *vmconfigs.MachineConfig, port int) error {
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 
 	if err := wslInvoke(dist, "sh", "-c", fmt.Sprintf(changePort, port)); err != nil {
 		return fmt.Errorf("could not change SSH port for guest OS: %w", err)

--- a/vendor/github.com/containers/podman/v5/pkg/machine/wsl/usermodenet.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/wsl/usermodenet.go
@@ -104,7 +104,7 @@ func startUserModeNetworking(mc *vmconfigs.MachineConfig) error {
 		}
 	}
 
-	if err := createUserModeResolvConf(env.WithPodmanPrefix(mc.Name)); err != nil {
+	if err := createUserModeResolvConf(env.WithToolPrefix(mc.Name)); err != nil {
 		return err
 	}
 
@@ -274,7 +274,7 @@ func addUserModeNetEntry(mc *vmconfigs.MachineConfig) error {
 		return err
 	}
 
-	path := filepath.Join(entriesDir, env.WithPodmanPrefix(mc.Name))
+	path := filepath.Join(entriesDir, env.WithToolPrefix(mc.Name))
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("could not add user-mode networking registration: %w", err)
@@ -289,7 +289,7 @@ func removeUserModeNetEntry(name string) error {
 		return err
 	}
 
-	path := filepath.Join(entriesDir, env.WithPodmanPrefix(name))
+	path := filepath.Join(entriesDir, env.WithToolPrefix(name))
 	return os.Remove(path)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -256,7 +256,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a
 ## explicit; go 1.22.8
 github.com/containers/podman/v5/libpod/define
 github.com/containers/podman/v5/pkg/errorhandling
@@ -1109,5 +1109,5 @@ gopkg.in/yaml.v3
 # tags.cncf.io/container-device-interface v0.8.1
 ## explicit; go 1.20
 tags.cncf.io/container-device-interface/pkg/parser
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250312163251-08cc816ea0e1
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
it sets the env variable PODMAN_TOOL_PREFIX so that the WSL distro name does not overlap with a podman machine.

it needs https://github.com/cfergeau/podman/pull/6 to be merged first and the podman dep updated