### PR TITLE
return error if start non-existing machine

### DIFF
--- a/cmd/macadam/start.go
+++ b/cmd/macadam/start.go
@@ -5,13 +5,13 @@ package main
 import (
 	"fmt"
 
-	"github.com/crc-org/macadam/cmd/macadam/registry"
-	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	ldefine "github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/shim"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	"github.com/spf13/cobra"
 )
 
@@ -63,10 +63,7 @@ func start(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if vmConfig == nil {
-		err = shim.Init(*initOpts, vmProvider)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("VM %s does not exist", machineName)
 	}
 
 	return macadam.Start(vmConfig, vmProvider)


### PR DESCRIPTION
this patch removes the creation process if the machine that wants to be started does not exist.

The main reason is that we are going to support multiple machines in the near future and having such a functionality can be problematic. What if the user just write the machine name wrongly? It will start an unwanted init process.

This commit just removes it and return an error message if the machine does not exist.

it resolves #107 