### PR TITLE
github actions improvements

### DIFF
--- a/.github/workflows/macadam.yml
+++ b/.github/workflows/macadam.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   workflow_dispatch:
   push:
+    branches:
+      - "main"
   pull_request: {}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04 # explicitly use 22.04 for binary compatibility with older distros
+    timeout-minutes: 30
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: >-
+        WORKAROUND: Fetch tags that points to the revisions
+        checked-out(actions/checkout#1467)
+      run: |-
+        git fetch --tags --force
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Build
+      run: |
+        make cross
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: macadam-binaries
+        path: bin/*
+
+    - name: Create release on github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+          gh release create --draft --generate-notes --verify-tag ${{github.ref_name}}
+          cd bin
+          sha256sum * >> sha256sums
+          gh release upload ${{github.ref_name}} *


### PR DESCRIPTION
This adds a release workflow to automate most of the release work, and this limits builds on pushes to avoid wasted (duplicated) work.