### PR TITLE
Add support for building macOS pkg installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bin
+**.DS_Store

--- a/packaging/darwin/.gitignore
+++ b/packaging/darwin/.gitignore
@@ -1,0 +1,5 @@
+out
+Distribution
+welcome.html
+tmp-bin
+root

--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-script minSpecVersion="1.000000">
+    <title>Macadam __VERSION__</title>
+    <welcome file="welcome.html" mime-type="text/html" />
+    <conclusion file="conclusion.html" mime-type="text/html" />
+    <license file="LICENSE.txt"/>
+    <options customize="never" hostArchitectures="x86_64,arm64" />
+    <domains enable_localSystem="true" />
+    <choices-outline>
+        <line choice="macadam"/>
+    </choices-outline>
+    <choice id="macadam" title="Macadam" enabled="false" selected="true" visible="true">
+        <pkg-ref id="macadam.pkg"/>
+    </choice>
+    <pkg-ref id="macadam.pkg">macadam.pkg</pkg-ref>
+</installer-script>

--- a/packaging/darwin/Makefile
+++ b/packaging/darwin/Makefile
@@ -1,0 +1,69 @@
+SHELL := bash
+
+MACADAM_VERSION = 0.0.2
+GVPROXY_VERSION ?= 0.8.5
+VFKIT_VERSION ?= 0.6.1
+GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
+VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned
+PACKAGE_DIR ?= out/packaging
+TMP_BIN ?= tmp-bin
+PACKAGE_ROOT ?= root
+PKG_NAME := macadam-installer-macos-universal.pkg
+
+.PHONY: pkginstaller packagedir
+default: pkginstaller
+
+$(TMP_BIN)/gvproxy:
+	mkdir -p $(TMP_BIN)
+	cd $(TMP_BIN) && curl -sLo gvproxy $(GVPROXY_RELEASE_URL)
+
+$(TMP_BIN)/vfkit:
+	mkdir -p $(TMP_BIN)
+	cd $(TMP_BIN) && curl -sLo vfkit $(VFKIT_RELEASE_URL)
+
+$(TMP_BIN)/macadam:
+	mkdir -p $(TMP_BIN)
+	$(MAKE) -C ../.. bin/macadam-darwin-amd64
+	$(MAKE) -C ../.. bin/macadam-darwin-arm64
+	cp ../../bin/macadam-darwin-amd64 $(TMP_BIN)/macadam-darwin-amd64
+	cp ../../bin/macadam-darwin-arm64 $(TMP_BIN)/macadam-darwin-arm64
+
+packagedir: package_root Distribution welcome.html
+	mkdir -p $(PACKAGE_DIR)
+	cp -r Resources $(PACKAGE_DIR)/
+	cp welcome.html $(PACKAGE_DIR)/Resources/
+	cp Distribution $(PACKAGE_DIR)/
+	cp -r scripts $(PACKAGE_DIR)/
+	cp -r $(PACKAGE_ROOT) $(PACKAGE_DIR)/
+	cp package.sh $(PACKAGE_DIR)/
+	cd $(PACKAGE_DIR) && pkgbuild --analyze --root ./root component.plist
+# Modify echo with an executable like podman
+	echo '$(MACADAM_VERSION)' > $(PACKAGE_DIR)/VERSION
+	cp vfkit.entitlements $(PACKAGE_DIR)/
+
+package_root: clean-pkgroot $(TMP_BIN)/gvproxy $(TMP_BIN)/vfkit $(TMP_BIN)/macadam
+	mkdir -p $(PACKAGE_ROOT)/macadam/bin
+	cp $(TMP_BIN)/gvproxy $(PACKAGE_ROOT)/macadam/bin/
+	cp $(TMP_BIN)/vfkit $(PACKAGE_ROOT)/macadam/bin/
+	cp $(TMP_BIN)/macadam-darwin-amd64 $(PACKAGE_ROOT)/macadam/bin/
+	cp $(TMP_BIN)/macadam-darwin-arm64 $(PACKAGE_ROOT)/macadam/bin/
+	chmod a+x $(PACKAGE_ROOT)/macadam/bin/*
+
+%: %.in
+	@sed -e 's/__VERSION__/'$(MACADAM_VERSION)'/g' $< >$@
+
+pkginstaller: packagedir
+	cd $(PACKAGE_DIR) && ./package.sh ..
+
+_notarize: pkginstaller
+	xcrun notarytool submit --apple-id $(NOTARIZE_USERNAME) --password $(NOTARIZE_PASSWORD) --team-id=$(NOTARIZE_TEAM) -f json --wait out/$(PKG_NAME)
+
+notarize: _notarize
+	xcrun stapler staple out/$(PKG_NAME)
+
+.PHONY: clean clean-pkgroot
+clean:
+	rm -rf $(TMP_BIN) $(PACKAGE_ROOT) $(PACKAGE_DIR) out Distribution welcome.html ../../test/version/version
+
+clean-pkgroot:
+	rm -rf $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html

--- a/packaging/darwin/README.md
+++ b/packaging/darwin/README.md
@@ -1,0 +1,21 @@
+## How to build
+
+```sh
+$ make NO_CODESIGN=1 pkginstaller
+
+# or to create signed pkg
+$ make CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> pkginstaller
+
+# or to prepare a signed and notarized pkg for release
+$ make CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> NOTARIZE_USERNAME=<appleID> NOTARIZE_PASSWORD=<appleID-password> NOTARIZE_TEAM=<team-id> notarize
+```
+
+The generated pkg will be written to `out/macadam-macos-installer-universal.pkg`.
+Currently the pkg installs `macadam`, `vfkit`, and `gvproxy` to `/opt/macadam`
+
+## Uninstalling
+
+```sh
+$ sudo pkgutil --forget com.redhat.macadam
+$ sudo rm -rf /opt/macadam
+```

--- a/packaging/darwin/Resources/conclusion.html
+++ b/packaging/darwin/Resources/conclusion.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+</head>
+<body>
+<div align="left" style="font-family: Helvetica; padding-left: 10px;">
+    <br/>
+    <p style="color: #020202; font-size: 12px;">Thanks for installing Macadam!</p>
+    <p style="color: #020202; font-size: 12px;">You can now start using the 'macadam' command. First run 'macadam init'</b>.</p>
+</div>
+</body>
+</html>

--- a/packaging/darwin/package.sh
+++ b/packaging/darwin/package.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euxo pipefail
+
+BASEDIR=$(dirname "$0")
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <output>" >&2
+  exit 1
+fi
+OUTPUT=$1
+
+CODESIGN_IDENTITY=${CODESIGN_IDENTITY:--}
+PRODUCTSIGN_IDENTITY=${PRODUCTSIGN_IDENTITY:-mock}
+NO_CODESIGN=${NO_CODESIGN:-0}
+
+binDir="${BASEDIR}/root/macadam/bin"
+
+version=$(cat "${BASEDIR}/VERSION")
+
+function build_fat(){
+    echo "Creating universal binary"
+    lipo -create -output "${binDir}/macadam" "${binDir}/macadam-darwin-arm64" "${binDir}/macadam-darwin-amd64"
+}
+
+function sign() {
+  local opts=""
+  entitlements="${BASEDIR}/$(basename "$1").entitlements"
+  if [ -f "${entitlements}" ]; then
+      opts="--entitlements ${entitlements}"
+  fi
+  codesign --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp --force ${opts} "$1"
+}
+
+build_fat
+
+sign "${binDir}/macadam"
+sign "${binDir}/gvproxy"
+sign "${binDir}/vfkit"
+
+pkgbuild --identifier com.redhat.macadam --version ${version} \
+  --scripts "${BASEDIR}/scripts" \
+  --root "${BASEDIR}/root" \
+  --install-location /opt \
+  --component-plist "${BASEDIR}/component.plist" \
+  "${OUTPUT}/macadam.pkg"
+
+productbuild --distribution "${BASEDIR}/Distribution" \
+  --resources "${BASEDIR}/Resources" \
+  --package-path "${OUTPUT}" \
+  "${OUTPUT}/macadam-unsigned.pkg"
+rm -f "${OUTPUT}/macadam.pkg"
+
+if [ ! "${NO_CODESIGN}" -eq "1" ]; then
+  productsign --timestamp --sign "${PRODUCTSIGN_IDENTITY}" "${OUTPUT}/macadam-unsigned.pkg" "${OUTPUT}/macadam-installer-macos-universal.pkg"
+else
+  mv "${OUTPUT}/macadam-unsigned.pkg" "${OUTPUT}/macadam-installer-macos-universal.pkg"
+fi

--- a/packaging/darwin/scripts/postinstall
+++ b/packaging/darwin/scripts/postinstall
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d "/etc/paths.d" ]; then
+    mkdir -p /etc/paths.d
+fi
+
+echo "/opt/macadam/bin" > /etc/paths.d/macadam-pkg

--- a/packaging/darwin/scripts/preinstall
+++ b/packaging/darwin/scripts/preinstall
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+rm -rf /opt/macadam

--- a/packaging/darwin/vfkit.entitlements
+++ b/packaging/darwin/vfkit.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.virtualization</key>
+	<true/>
+</dict>
+</plist>

--- a/packaging/darwin/welcome.html.in
+++ b/packaging/darwin/welcome.html.in
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+</head>
+<body>
+<div align="left" style="font-family: Helvetica; padding-left: 10px;">
+    <br/>
+    <p style="color: #020202; font-size: 12px;">This will install <span style="color: #46b9d6; font-size: 12px;">Macadam __VERSION__</span>
+        on your computer. You will be guided through the steps necessary to install this software.</p>
+    <br/>
+    <p style="color: #abb0b0; font-size: 12px;">Click <span style="color: #626666">“Continue"</span> to continue the
+        setup</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
it allows to create a pkg installer to install macadam and its supporting binaries (vfkit, gvproxy).

macadam is compiled from source
gvproxy and vfkit binaries are downloaded from their github releases

## Summary by Sourcery

Add macOS pkg installer support for macadam and its supporting binaries

New Features:
- Create a macOS package installer for macadam that includes macadam, gvproxy, and vfkit binaries

Build:
- Add Makefile for building macOS pkg installer with support for different architectures
- Implement package build scripts for macOS installer

Deployment:
- Create package installation scripts and resources for macOS pkg installer
- Support code signing and notarization for the macOS package

Documentation:
- Add README with instructions for building and installing the macOS package