### PR TITLE
Make ready units/socket forwarding optional

### DIFF
--- a/cmd/macadam/init.go
+++ b/cmd/macadam/init.go
@@ -204,6 +204,10 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	initOpts.SSHIdentityPath = initOptsFromFlags.SSHIdentityPath
 	initOpts.Username = initOptsFromFlags.Username
 	initOpts.CloudInit = true // this should be calculated based on the image we want to start ??
+	initOpts.Capabilities = &define.MachineCapabilities{
+		HasReadyUnit:   false,
+		ForwardSockets: false,
+	}
 	/*
 		_, _, err = shim.VMExists(machineName, []vmconfigs.VMProvider{provider})
 		if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -209,6 +209,6 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250409120238-38e347ba8686
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a h1:gmSGx5qMxAuAgi2S0ls95/9MzRLDmZVVhMExn6kVI9o=
-github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a/go.mod h1:IFzo7ohforx759kkElhbTkrv0+9W+8QfjdqbVTq2bcw=
+github.com/cfergeau/podman/v5 v5.0.0-20250409120238-38e347ba8686 h1:PEw3LFyGi1uYat9gYx6nMfvOqlAf05HKRlKsCFZbRQc=
+github.com/cfergeau/podman/v5 v5.0.0-20250409120238-38e347ba8686/go.mod h1:IFzo7ohforx759kkElhbTkrv0+9W+8QfjdqbVTq2bcw=
 github.com/checkpoint-restore/checkpointctl v1.3.0 h1:bNz5b6s+lxFdG5ZGDba3qSkBtXDDTCG2494dfAbQJ4E=
 github.com/checkpoint-restore/checkpointctl v1.3.0/go.mod h1:dqZH4wDvbjnsqFGK2LdUDk21yFQ1dCAtzgRMlG44KDM=
 github.com/checkpoint-restore/go-criu/v7 v7.2.0 h1:qGiWA4App1gGlEfIJ68WR9jbezV9J7yZdjzglezcqKo=

--- a/pkg/machinedriver/driver.go
+++ b/pkg/machinedriver/driver.go
@@ -303,7 +303,9 @@ func Start(vmConfig *vmconfigs.MachineConfig, vmProvider vmconfigs.VMProvider) e
 	fmt.Printf("Starting machine %q\n", machineName)
 
 	startOpts := machine.StartOptions{
-		NoInfo: false,
+		// The ForwardSockets capabilities roughly indicates if we have a podman machine or a generic VM.
+		// For generic VMs, we don’t want to print these `info` messages as they are podman-centric.
+		NoInfo: !vmConfig.Capabilities.GetForwardSockets(),
 		Quiet:  false,
 	}
 	slog.Info(fmt.Sprintf("SSH config: %v", vmConfig.SSH))

--- a/vendor/github.com/containers/podman/v5/pkg/machine/apple/apple.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/apple/apple.go
@@ -148,8 +148,8 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	if err != nil {
 		return nil, nil, err
 	}
-	// Set user networking with gvproxy
 
+	// Set user networking with gvproxy
 	gvproxySocket, err := mc.GVProxySocket()
 	if err != nil {
 		return nil, nil, err
@@ -238,18 +238,20 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 		cmd.Args = append(cmd.Args, firstBootCli...)
 	}
 
-	logrus.Debugf("listening for ready on: %s", readySocket.GetPath())
-	if err := readySocket.Delete(); err != nil {
-		logrus.Warnf("unable to delete previous ready socket: %q", err)
-	}
-	readyListen, err := net.Listen("unix", readySocket.GetPath())
-	if err != nil {
-		return nil, nil, err
-	}
-
-	logrus.Debug("waiting for ready notification")
 	readyChan := make(chan error)
-	go sockets.ListenAndWaitOnSocket(readyChan, readyListen)
+	if readySocket != nil {
+		logrus.Debugf("listening for ready on: %s", readySocket.GetPath())
+		if err := readySocket.Delete(); err != nil {
+			logrus.Warnf("unable to delete previous ready socket: %q", err)
+		}
+		readyListen, err := net.Listen("unix", readySocket.GetPath())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		logrus.Debug("waiting for ready notification")
+		go sockets.ListenAndWaitOnSocket(readyChan, readyListen)
+	}
 
 	logrus.Debugf("helper command-line: %v", cmd.Args)
 

--- a/vendor/github.com/containers/podman/v5/pkg/machine/define/initopts.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/define/initopts.go
@@ -2,6 +2,27 @@ package define
 
 import "net/url"
 
+type MachineCapabilities struct {
+	HasReadyUnit   bool
+	ForwardSockets bool
+}
+
+func (caps *MachineCapabilities) GetForwardSockets() bool {
+	if caps == nil {
+		// if there are no known capabilities, honor default podman-machine behaviour
+		return true
+	}
+	return caps.ForwardSockets
+}
+
+func (caps *MachineCapabilities) GetHasReadyUnit() bool {
+	if caps == nil {
+		// if there are no known capabilities, honor default podman-machine behaviour
+		return true
+	}
+	return caps.HasReadyUnit
+}
+
 type InitOptions struct {
 	PlaybookPath       string
 	CPUS               uint64
@@ -23,4 +44,5 @@ type InitOptions struct {
 	USBs               []string
 	ImagePuller        ImagePuller
 	CloudInit          bool
+	Capabilities       *MachineCapabilities
 }

--- a/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking.go
@@ -112,9 +112,17 @@ func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 		return "", 0, err
 	}
 
-	hostSocks, forwardSock, forwardingState, err := setupMachineSockets(mc, dirs)
-	if err != nil {
-		return "", 0, err
+	var (
+		hostSocks       []string
+		forwardSock     string
+		forwardingState machine.APIForwardingState
+	)
+
+	if mc.Capabilities.GetForwardSockets() {
+		hostSocks, forwardSock, forwardingState, err = setupMachineSockets(mc, dirs)
+		if err != nil {
+			return "", 0, err
+		}
 	}
 
 	if err := startHostForwarder(mc, provider, dirs, hostSocks); err != nil {

--- a/vendor/github.com/containers/podman/v5/pkg/machine/sockets/sockets.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/sockets/sockets.go
@@ -14,22 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SetSocket creates a new machine file for the socket and assigns it to
-// `socketLoc`
-func SetSocket(socketLoc *define.VMFile, path string, symlink *string) error {
-	socket, err := define.NewMachineFile(path, symlink)
-	if err != nil {
-		return err
-	}
-	*socketLoc = *socket
-	return nil
-}
-
-// ReadySocketPath returns the filepath for the ready socket
-func ReadySocketPath(runtimeDir, machineName string) string {
-	return filepath.Join(runtimeDir, fmt.Sprintf("%s_ready.sock", machineName))
-}
-
 // ListenAndWaitOnSocket waits for a new connection to the listener and sends
 // any error back through the channel. ListenAndWaitOnSocket is intended to be
 // used as a goroutine

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config.go
@@ -56,7 +56,8 @@ type MachineConfig struct {
 
 	Ansible *AnsibleConfig
 
-	CloudInit bool
+	CloudInit    bool
+	Capabilities *define.MachineCapabilities
 }
 
 type machineImage interface { //nolint:unused

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine.go
@@ -181,11 +181,14 @@ func (mc *MachineConfig) Remove(machines map[string]bool, saveIgnition, saveImag
 
 	rmFiles := []string{
 		mc.configPath.GetPath(),
-		readySocket.GetPath(),
 		gvProxySocket.GetPath(),
 		apiSocket.GetPath(),
 		logPath.GetPath(),
 	}
+	if mc.Capabilities.GetHasReadyUnit() {
+		rmFiles = append(rmFiles, readySocket.GetPath())
+	}
+
 	if !saveImage {
 		mc.ImagePath.GetPath()
 	}
@@ -195,8 +198,10 @@ func (mc *MachineConfig) Remove(machines map[string]bool, saveIgnition, saveImag
 
 	mcRemove := func() error {
 		var errs []error
-		if err := connection.RemoveConnections(machines, mc.Name, mc.Name+"-root"); err != nil {
-			errs = append(errs, err)
+		if mc.Capabilities.GetForwardSockets() {
+			if err := connection.RemoveConnections(machines, mc.Name, mc.Name+"-root"); err != nil {
+				errs = append(errs, err)
+			}
 		}
 
 		if !saveIgnition {
@@ -209,8 +214,10 @@ func (mc *MachineConfig) Remove(machines map[string]bool, saveIgnition, saveImag
 				errs = append(errs, err)
 			}
 		}
-		if err := readySocket.Delete(); err != nil {
-			errs = append(errs, err)
+		if mc.Capabilities.GetHasReadyUnit() {
+			if err := readySocket.Delete(); err != nil {
+				errs = append(errs, err)
+			}
 		}
 		if err := gvProxySocket.Delete(); err != nil {
 			errs = append(errs, err)

--- a/vendor/github.com/containers/podman/v5/pkg/machine/wsl/declares.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/wsl/declares.go
@@ -28,7 +28,6 @@ const appendPort = `grep -q Port\ %d /etc/ssh/sshd_config || echo Port %d >> /et
 const changePort = `sed -E -i 's/^Port[[:space:]]+[0-9]+/Port %d/' /etc/ssh/sshd_config`
 
 const configServices = `ln -fs /usr/lib/systemd/system/sshd.service /etc/systemd/system/multi-user.target.wants/sshd.service
-ln -fs /usr/lib/systemd/system/podman.socket /etc/systemd/system/sockets.target.wants/podman.socket
 rm -f /etc/systemd/system/getty.target.wants/console-getty.service
 rm -f /etc/systemd/system/getty.target.wants/getty@tty1.service
 rm -f /etc/systemd/system/multi-user.target.wants/systemd-resolved.service
@@ -42,6 +41,10 @@ adduser -m [USER] -G wheel
 mkdir -p /home/[USER]/.config/systemd/[USER]/
 chown [USER]:[USER] /home/[USER]/.config
 `
+
+const configServicesPodman = `mkdir -p /etc/containers/registries.conf.d
+ln -fs /usr/lib/systemd/system/podman.socket /etc/systemd/system/sockets.target.wants/podman.socket
+` + configServices
 
 const sudoers = `%wheel        ALL=(ALL)       NOPASSWD: ALL
 `

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -345,7 +345,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250409120238-38e347ba8686
 ## explicit; go 1.22.8
 github.com/containers/podman/v5/cmd/podman/parse
 github.com/containers/podman/v5/cmd/podman/registry
@@ -1376,5 +1376,5 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250318103339-fc7e59cbee4a
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250409120238-38e347ba8686
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
This uses the newly introduced capabilities in podman-machine to disable podman socket forwarding and waiting for notifications from the podman-ready systemd units in the guest.

With this work, it’s possible to start an unmodified rhel cloud image at least on macOS. I haven’t tested it on wsl..

## Summary by Sourcery

Add support for optional socket forwarding and ready units when initializing machines

New Features:
- Enable starting unmodified cloud images by making socket forwarding and ready units configurable

Enhancements:
- Introduce machine initialization capabilities to disable podman socket forwarding and ready unit notifications