### PR TITLE
init: add flag to disable user network mode

### DIFF
--- a/cmd/macadam/init.go
+++ b/cmd/macadam/init.go
@@ -30,8 +30,8 @@ var (
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
 
-	initOptsFromFlags = define.InitOptions{}
-	// initOptionalFlags  = InitOptionalFlags{}
+	initOptsFromFlags  = define.InitOptions{}
+	initOptionalFlags  = InitOptionalFlags{}
 	defaultMachineName = "macadam"
 	// now                bool
 )
@@ -75,6 +75,10 @@ func init() {
 	memoryFlagName := "memory"
 	flags.Uint64VarP(&initOptsFromFlags.Memory, memoryFlagName, "m", 4096, "Memory in MiB")
 	_ = initCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
+
+	userModeNetFlagName := "user-mode-networking"
+	flags.BoolVar(&initOptionalFlags.UserModeNetworking, userModeNetFlagName, true,
+		"Whether this machine should use user-mode networking, routing traffic through a host user-space process")
 
 	/* flags := initCmd.Flags()
 	cfg := registry.PodmanConfig()
@@ -136,16 +140,15 @@ func init() {
 	_ = initCmd.RegisterFlagCompletionFunc(IgnitionPathFlagName, completion.AutocompleteDefault)
 
 	rootfulFlagName := "rootful"
-	flags.BoolVar(&initOpts.Rootful, rootfulFlagName, false, "Whether this machine should prefer rootful container execution")
+	flags.BoolVar(&initOpts.Rootful, rootfulFlagName, false, "Whether this machine should prefer rootful container execution") */
 
-	userModeNetFlagName := "user-mode-networking"
-	flags.BoolVar(&initOptionalFlags.UserModeNetworking, userModeNetFlagName, false,
-		"Whether this machine should use user-mode networking, routing traffic through a host user-space process") */
 }
 
 func runPreflights() error {
-	if err := preflights.CheckGvproxyVersion(); err != nil {
-		return fmt.Errorf("invalid gvproxy binary: %w", err)
+	if initOptionalFlags.UserModeNetworking {
+		if err := preflights.CheckGvproxyVersion(); err != nil {
+			return fmt.Errorf("invalid gvproxy binary: %w", err)
+		}
 	}
 
 	if err := preflights.CheckVfkitVersion(); err != nil {
@@ -204,6 +207,11 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	initOpts.SSHIdentityPath = initOptsFromFlags.SSHIdentityPath
 	initOpts.Username = initOptsFromFlags.Username
 	initOpts.CloudInit = true // this should be calculated based on the image we want to start ??
+	initOpts.UserModeNetworking = nil
+
+	if initOptionalFlags.UserModeNetworking {
+		initOpts.UserModeNetworking = &initOptionalFlags.UserModeNetworking
+	}
 	/*
 		_, _, err = shim.VMExists(machineName, []vmconfigs.VMProvider{provider})
 		if err == nil {

--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -49,8 +49,8 @@ func CheckSupportedProviders() error {
 	}
 	vmType := provider.VMType()
 	switch vmType {
-	case define.HyperVVirt, define.LibKrun:
-		return fmt.Errorf("%s VM provider is unsupported, only wsl2 on Windows, vfkit on macOS and qemu on linux are supported", vmType.String())
+	case define.LibKrun:
+		return fmt.Errorf("%s VM provider is unsupported, only wsl2, hyperv on Windows, vfkit on macOS and qemu on linux are supported", vmType.String())
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary by Sourcery

Add a configuration flag to disable user-mode networking for machine initialization

New Features:
- Introduce a new flag '--user-mode-networking' to control user-mode network routing for machine initialization

Enhancements:
- Modify preflight checks to conditionally validate gvproxy based on user-mode networking setting
- Update machine initialization to optionally set user-mode networking configuration

Chores:
- Remove commented-out code related to previous networking configurations
- Update supported provider error message to include HyperV support