### PR TITLE
add preflight command

### DIFF
--- a/cmd/macadam/init.go
+++ b/cmd/macadam/init.go
@@ -143,24 +143,8 @@ func init() {
 		"Whether this machine should use user-mode networking, routing traffic through a host user-space process") */
 }
 
-func runPreflights() error {
-	if err := preflights.CheckGvproxyVersion(); err != nil {
-		return fmt.Errorf("invalid gvproxy binary: %w", err)
-	}
-
-	if err := preflights.CheckVfkitVersion(); err != nil {
-		return fmt.Errorf("invalid vfkit binary: %w", err)
-	}
-
-	if err := preflights.CheckSupportedProviders(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func initMachine(cmd *cobra.Command, args []string) error {
-	if err := runPreflights(); err != nil {
+	if err := preflights.RunPreflights(); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/macadam/preflight.go
+++ b/cmd/macadam/preflight.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/crc-org/macadam/cmd/macadam/registry"
+	"github.com/crc-org/macadam/pkg/preflights"
+	"github.com/spf13/cobra"
+)
+
+var (
+	preflightsCmd = &cobra.Command{
+		Use:     "preflight",
+		Short:   "Perform preflight checks on an existing machine",
+		Long:    "Perform preflight checks on a managed virtual machine ",
+		RunE:    preflight,
+		Args:    cobra.MaximumNArgs(0),
+		Example: `macadam preflight`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: preflightsCmd,
+	})
+}
+
+func preflight(_ *cobra.Command, args []string) error {
+	return preflights.RunPreflights()
+}

--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -53,7 +53,7 @@ func checkVfkitVersion() error {
 		return nil
 	}
 	if err := checkBinaryArg("vfkit", "--cloud-init"); err != nil {
-		return fmt.Errorf("%w, please update to vfkit from git main", err)
+		return fmt.Errorf("%w, please update to vfkit v0.6.1 or newer", err)
 	}
 	return nil
 }

--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -13,9 +13,25 @@ import (
 	provider2 "github.com/containers/podman/v5/pkg/machine/provider"
 )
 
+func RunPreflights() error {
+	if err := checkGvproxyVersion(); err != nil {
+		return fmt.Errorf("invalid gvproxy binary: %w", err)
+	}
+
+	if err := checkVfkitVersion(); err != nil {
+		return fmt.Errorf("invalid vfkit binary: %w", err)
+	}
+
+	if err := checkSupportedProviders(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // macadam/podman needs a gvproxy version which supports the --services
 // argument
-func CheckGvproxyVersion() error {
+func checkGvproxyVersion() error {
 	provider, err := provider2.Get()
 	if err != nil {
 		return err
@@ -32,7 +48,7 @@ func CheckGvproxyVersion() error {
 
 // macadam/podman needs a vfkit binary which supports the --cloud-init
 // argument to inject ssh keys in RHEL cloud images
-func CheckVfkitVersion() error {
+func checkVfkitVersion() error {
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
@@ -42,7 +58,7 @@ func CheckVfkitVersion() error {
 	return nil
 }
 
-func CheckSupportedProviders() error {
+func checkSupportedProviders() error {
 	provider, err := provider2.Get()
 	if err != nil {
 		return err


### PR DESCRIPTION
it adds a preflight command to allow performing preflight checks on request. This will be used by the podman desktop extension

it resolves #150

## Summary by Sourcery

Add a new preflight command to perform system compatibility checks for the Macadam virtual machine management tool

New Features:
- Introduce a new 'preflight' command that allows users to run system compatibility checks independently

Enhancements:
- Refactor preflight checks into a separate common package for reusability
- Move preflight check logic from init function to a dedicated command

Chores:
- Reorganize code structure to separate preflight check logic