### PR TITLE
macos: Remove arch binaries after running lipo

### DIFF
--- a/packaging/darwin/package.sh
+++ b/packaging/darwin/package.sh
@@ -20,6 +20,7 @@ version=$(cat "${BASEDIR}/VERSION")
 function build_fat(){
     echo "Creating universal binary"
     lipo -create -output "${binDir}/macadam" "${binDir}/macadam-darwin-arm64" "${binDir}/macadam-darwin-amd64"
+    rm "${binDir}/macadam-darwin-arm64" "${binDir}/macadam-darwin-amd64"
 }
 
 function sign() {


### PR DESCRIPTION
package.sh is using `lipo` to create a universal macadam binary.
After creating the universal `macadam` binary, the `macadam-darwin-*`
binaries were left behind and needlessly added to the installer.

## Summary by Sourcery

Remove architecture-specific binaries after creating a universal macOS binary

Build:
- Modify packaging script to remove arm64 and amd64 binaries after creating a universal macOS binary

Chores:
- Clean up temporary architecture-specific binaries after creating a universal binary using lipo