### PR TITLE
update podman dep to skip applyProxies on non podman machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,6 +217,6 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250418120702-62ce2752a330
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250418120702-62ce2752a330 h1:crU9eu4l8W+2nUgwArPtctltRN1v6lLg3Yldg5g3wRs=
-github.com/cfergeau/podman/v5 v5.0.0-20250418120702-62ce2752a330/go.mod h1:8a5qQz+BsxitEQjdsHKGz9WxuYCpKpS1ZgViyhim01w=
+github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1 h1:BmOn86tHWueGv6rCbcqxHa0ZvxNlj7WOMfYCB0QUdig=
+github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1/go.mod h1:8a5qQz+BsxitEQjdsHKGz9WxuYCpKpS1ZgViyhim01w=
 github.com/checkpoint-restore/checkpointctl v1.3.0 h1:bNz5b6s+lxFdG5ZGDba3qSkBtXDDTCG2494dfAbQJ4E=
 github.com/checkpoint-restore/checkpointctl v1.3.0/go.mod h1:dqZH4wDvbjnsqFGK2LdUDk21yFQ1dCAtzgRMlG44KDM=
 github.com/checkpoint-restore/go-criu/v7 v7.2.0 h1:qGiWA4App1gGlEfIJ68WR9jbezV9J7yZdjzglezcqKo=

--- a/vendor/github.com/containers/podman/v5/pkg/machine/shim/host.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/shim/host.go
@@ -557,8 +557,12 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDe
 
 	// this expects to be able to ssh as root to the VM - switch to regular user + sudo?
 	// -> move it to a "PostStartVM()" interface method?
-	if err := proxyenv.ApplyProxies(mc); err != nil {
-		return err
+	// this is a temporary solution to skip applying proxies for non-podman machines bc of a problem with bootc/macadam
+	// however this should be replaced by a specific IsBootc property
+	if mc.Capabilities.GetForwardSockets() {
+		if err := proxyenv.ApplyProxies(mc); err != nil {
+			return err
+		}
 	}
 
 	// mount the volumes to the VM

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250418120702-62ce2752a330
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1
 ## explicit; go 1.22.8
 github.com/containers/podman/v5/cmd/podman/parse
 github.com/containers/podman/v5/cmd/podman/registry
@@ -1445,5 +1445,5 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250418120702-62ce2752a330
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update Podman dependency to a specific fork with a fix for proxy handling