### PR TITLE
gha: Upload executables for all oses/arches

### DIFF
--- a/.github/workflows/macadam.yml
+++ b/.github/workflows/macadam.yml
@@ -39,8 +39,8 @@ jobs:
         if: matrix.go == 'stable'
         uses: actions/upload-artifact@v4
         with:
-          name: amd64 linux binary
-          path: "./bin/macadam-linux-amd64"
+          name: macadam binaries
+          path: "./bin/*"
 
 
   test:


### PR DESCRIPTION
Better to upload all binaries instead of only uploaded the linux/amd64
binary.

## Summary by Sourcery

CI:
- Update artifact upload configuration to include binaries for all platforms instead of just Linux/AMD64