### PR TITLE
run e2e in gh workflow

### DIFF
--- a/.github/workflows/macadam.yml
+++ b/.github/workflows/macadam.yml
@@ -64,6 +64,45 @@ jobs:
       - name: Test
         run: make test
 
+  e2e:
+    needs: build
+    strategy:
+      matrix:
+        os:
+        - ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macadam binaries
+          path: ./bin
+      - name: Setup qemu (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y qemu-kvm
+          sudo chmod 666 /dev/kvm
+      - name: Download gvproxy
+        if: runner.os == 'Linux'
+        run: |
+          wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.8.6/gvproxy-linux-amd64 -O ${{ github.workspace }}/tools/gvproxy
+          chmod +x ${{ github.workspace }}/tools/gvproxy
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'oldstable'
+      - name: Grant execute permissions
+        if: runner.os == 'Linux'
+        run: chmod +x ./bin/*
+      - name: Test
+        env:
+          CONTAINERS_HELPER_BINARY_DIR: ${{ github.workspace }}/tools
+        run: make e2e
 
   lint:
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ check: lint vendorcheck test
 test:
 	@go test -tags "$(BUILDTAGS)" -v ./pkg/...
 
+e2e:
+	@go test -tags "$(BUILDTAGS)" -v ./test/e2e/...
+
 clean:
 	@rm -rf bin
 

--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
-	github.com/ulikunitz/xz v0.5.12
+	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
 	github.com/vbauerster/mpb/v8 v8.9.3 // indirect
 	github.com/vishvananda/netlink v1.3.1-0.20250221194427-0af32151e72b // indirect

--- a/test/e2e/vm_test.go
+++ b/test/e2e/vm_test.go
@@ -42,11 +42,12 @@ var _ = Describe("Macadam", func() {
 	It("creates a new CentOS VM, starts it, ssh in and cleans", func() {
 		// verify there is no vm
 		var machineResponses []ListReporter
-		session := macadamTest.Macadam([]string{"list"})
+		session := macadamTest.Macadam([]string{"list", "--format", "json"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(gexec.Exit())
-		list := session.OutputToString()
-		Expect(list).Should(Equal(""))
+		err := json.Unmarshal(session.Out.Contents(), &machineResponses)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(machineResponses)).Should(Equal(0))
 
 		// download CentOS image
 		centosProvider := osprovider.NewCentosProvider()
@@ -59,11 +60,10 @@ var _ = Describe("Macadam", func() {
 		Expect(session).Should(gexec.Exit())
 
 		// check the list command returns one item
-		session = macadamTest.Macadam([]string{"list"})
+		session = macadamTest.Macadam([]string{"list", "--format", "json"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(gexec.Exit())
-		list = session.OutputToString()
-		err = json.Unmarshal([]byte(list), &machineResponses)
+		err = json.Unmarshal(session.Out.Contents(), &machineResponses)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(machineResponses)).Should(Equal(1))
 
@@ -90,11 +90,12 @@ var _ = Describe("Macadam", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(gexec.Exit())
 
-		session = macadamTest.Macadam([]string{"list"})
+		session = macadamTest.Macadam([]string{"list", "--format", "json"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(gexec.Exit())
-		list = session.OutputToString()
-		Expect(list).Should(Equal(""))
+		err = json.Unmarshal(session.Out.Contents(), &machineResponses)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(machineResponses)).Should(Equal(0))
 	})
 
 })

--- a/test/osprovider/centos.go
+++ b/test/osprovider/centos.go
@@ -17,11 +17,7 @@ func NewCentosProvider() *CentosProvider {
 func (centos *CentosProvider) Fetch(destDir string) (string, error) {
 	log.Infof("downloading centos to %s", destDir)
 	arch := kernelArch()
-	archInName := "-" + arch
-	if archInName == "-x86_64" {
-		archInName = ""
-	}
-	var centosURL = fmt.Sprintf("https://cloud.centos.org/centos/10-stream/%s/images/CentOS-Stream-ec2%s-10-20250324.0.%s.raw.xz", arch, archInName, arch)
+	centosURL := fmt.Sprintf("https://cloud.centos.org/centos/10-stream/%s/images/CentOS-Stream-GenericCloud-10-20250324.0.%s.qcow2", arch, arch)
 	file, err := downloadOS(destDir, centosURL)
 	if err != nil {
 		return "", err

--- a/test/osprovider/provider.go
+++ b/test/osprovider/provider.go
@@ -1,15 +1,9 @@
 package osprovider
 
 import (
-	"bufio"
-	"io"
-	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/cavaliergopher/grab/v3"
-	"github.com/ulikunitz/xz"
 )
 
 type OsProvider interface {
@@ -35,35 +29,5 @@ func downloadOS(destDir, url string) (string, error) {
 		return "", err
 	}
 
-	return uncompressXZ(resp.Filename, destDir)
-}
-
-func uncompressXZ(fileName string, targetDir string) (string, error) {
-	file, err := os.Open(filepath.Clean(fileName))
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	reader, err := xz.NewReader(file)
-	if err != nil {
-		return "", err
-	}
-
-	xzCutName, _ := strings.CutSuffix(filepath.Base(file.Name()), ".xz")
-	outPath := filepath.Join(targetDir, xzCutName)
-	out, err := os.Create(outPath)
-	if err != nil {
-		return "", err
-	}
-
-	bufferedWriter := bufio.NewWriter(out)
-	defer bufferedWriter.Flush()
-
-	_, err = io.Copy(bufferedWriter, reader)
-	if err != nil {
-		return "", err
-	}
-
-	return outPath, nil
+	return resp.Filename, nil
 }


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end (e2e) testing workflow to GitHub Actions and simplify OS image download process

Enhancements:
- Simplify CentOS image download URL and remove XZ decompression logic
- Update e2e tests to use JSON parsing for command output

CI:
- Add new e2e job to GitHub Actions workflow
- Configure e2e testing job with Linux runner and necessary setup steps

Tests:
- Add Makefile target for running e2e tests
- Modify e2e VM tests to use JSON unmarshaling for list command

Chores:
- Remove XZ decompression dependency
- Update Go module dependencies