### PR TITLE
go.mod: Update podman branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/containernetworking/cni v1.2.3 // indirect
 	github.com/containernetworking/plugins v1.5.1 // indirect
-	github.com/containers/buildah v1.39.1 // indirect
+	github.com/containers/buildah v1.39.4 // indirect
 	github.com/containers/conmon v2.0.20+incompatible // indirect
 	github.com/containers/gvisor-tap-vsock v0.8.5 // indirect
 	github.com/containers/image/v5 v5.34.3 // indirect
@@ -219,6 +219,6 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1 h1:BmOn86tHWueGv6rCbcqxHa0ZvxNlj7WOMfYCB0QUdig=
-github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1/go.mod h1:8a5qQz+BsxitEQjdsHKGz9WxuYCpKpS1ZgViyhim01w=
+github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d h1:l2D868gDqdOCzTBLj0ROB8ZTjvuyGMy+46p2I5zj6Y0=
+github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d/go.mod h1:p4TndXjITbW8STQps3U16QQdsZHl3Os2uQEl8Sy7XPM=
 github.com/checkpoint-restore/checkpointctl v1.3.0 h1:bNz5b6s+lxFdG5ZGDba3qSkBtXDDTCG2494dfAbQJ4E=
 github.com/checkpoint-restore/checkpointctl v1.3.0/go.mod h1:dqZH4wDvbjnsqFGK2LdUDk21yFQ1dCAtzgRMlG44KDM=
 github.com/checkpoint-restore/go-criu/v7 v7.2.0 h1:qGiWA4App1gGlEfIJ68WR9jbezV9J7yZdjzglezcqKo=
@@ -78,8 +78,8 @@ github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8F
 github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
 github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+E5J/EcKOE4gQ=
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
-github.com/containers/buildah v1.39.1 h1:Z2nh9Tf/xw0JVDirC8u/qzDHE8ntqkz1khdwPsl4p9U=
-github.com/containers/buildah v1.39.1/go.mod h1:M5BDDzRezS8/FbvGdh35FHbltteaMRElNrZ0LgX6UP8=
+github.com/containers/buildah v1.39.4 h1:XTL1+N9wJcSAqXUl4ReFK286QWLTIGp44jBqs9Qd2y0=
+github.com/containers/buildah v1.39.4/go.mod h1:EPFAYD/27eXceT8shzWxKg+asgorc8nzrjiG9qFCqTk=
 github.com/containers/common v0.62.3 h1:aOGryqXfW6aKBbHbqOveH7zB+ihavUN03X/2pUSvWFI=
 github.com/containers/common v0.62.3/go.mod h1:3R8kDox2prC9uj/a2hmXj/YjZz5sBEUNrcDiw51S0Lo=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 # Changelog
 
+## v1.39.4 (2025-03-27)
+
+    [release-1.39] Bump c/image to v5.34.3, c/common v0.62.3
+    createPlatformContainer: drop MS_REMOUNT|MS_BIND
+
+## v1.39.3 (2025-03-12)
+
+    [release-1.39] Bump c/storage to v1.57.2, c/image v5.34.2, c/common v0.62.2
+
+## v1.39.2 (2025-03-03)
+
+    [release-1.39] Bump c/image to v5.34.1, c/common v0.62.1
+
 ## v1.39.1 (2025-02-25)
 
     chroot createPlatformContainer: use MS_REMOUNT

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,13 @@
+- Changelog for v1.39.4 (2025-03-27)
+  * [release-1.39] Bump c/image to v5.34.3, c/common v0.62.3
+  * createPlatformContainer: drop MS_REMOUNT|MS_BIND
+
+- Changelog for v1.39.3 (2025-03-12)
+  * [release-1.39] Bump c/storage to v1.57.2, c/image v5.34.2, c/common v0.62.2
+
+- Changelog for v1.39.2 (2025-03-03)
+  * [release-1.39] Bump c/image to v5.34.1, c/common v0.62.1
+
 - Changelog for v1.39.1 (2025-02-25)
 
   * chroot createPlatformContainer: use MS_REMOUNT

--- a/vendor/github.com/containers/buildah/chroot/run_linux.go
+++ b/vendor/github.com/containers/buildah/chroot/run_linux.go
@@ -263,7 +263,7 @@ func createPlatformContainer(options runUsingChrootExecSubprocOptions) error {
 		return fmt.Errorf("changing to host root directory: %w", err)
 	}
 	// make sure we only unmount things under this tree
-	if err := unix.Mount(".", ".", "bind", unix.MS_REMOUNT|unix.MS_BIND|unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
+	if err := unix.Mount(".", ".", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
 		return fmt.Errorf("tweaking mount flags on host root directory before unmounting from mount namespace: %w", err)
 	}
 	// detach this (unnamed?) old directory

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.39.1"
+	Version = "1.39.4"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/podman/v5/cmd/podman/registry/registry.go
+++ b/vendor/github.com/containers/podman/v5/cmd/podman/registry/registry.go
@@ -21,7 +21,7 @@ type CliCommand struct {
 }
 
 var (
-	cliCtx          context.Context
+	cliCtx          = context.Background()
 	containerEngine entities.ContainerEngine
 	exitCode        = 0
 	imageEngine     entities.ImageEngine
@@ -81,28 +81,8 @@ func NewContainerEngine(cmd *cobra.Command, args []string) (entities.ContainerEn
 	return containerEngine, nil
 }
 
-type PodmanOptionsKey struct{}
-
 func Context() context.Context {
-	if cliCtx == nil {
-		cliCtx = ContextWithOptions(context.Background())
-	}
 	return cliCtx
-}
-
-func ContextWithOptions(ctx context.Context) context.Context {
-	cliCtx = context.WithValue(ctx, PodmanOptionsKey{}, podmanOptions)
-	return cliCtx
-}
-
-// GetContextWithOptions deprecated, use  NewContextWithOptions()
-func GetContextWithOptions() context.Context {
-	return ContextWithOptions(context.Background())
-}
-
-// GetContext deprecated, use  Context()
-func GetContext() context.Context {
-	return Context()
 }
 
 func DefaultAPIAddress() string {

--- a/vendor/github.com/containers/podman/v5/libpod/container.go
+++ b/vendor/github.com/containers/podman/v5/libpod/container.go
@@ -1291,6 +1291,27 @@ func (c *Container) HealthCheckConfig() *manifest.Schema2HealthConfig {
 	return c.config.HealthCheckConfig
 }
 
+func (c *Container) HealthCheckLogDestination() string {
+	if c.config.HealthLogDestination == nil {
+		return define.DefaultHealthCheckLocalDestination
+	}
+	return *c.config.HealthLogDestination
+}
+
+func (c *Container) HealthCheckMaxLogCount() uint {
+	if c.config.HealthMaxLogCount == nil {
+		return define.DefaultHealthMaxLogCount
+	}
+	return *c.config.HealthMaxLogCount
+}
+
+func (c *Container) HealthCheckMaxLogSize() uint {
+	if c.config.HealthMaxLogSize == nil {
+		return define.DefaultHealthMaxLogSize
+	}
+	return *c.config.HealthMaxLogSize
+}
+
 // AutoRemove indicates whether the container will be removed after it is executed
 func (c *Container) AutoRemove() bool {
 	spec := c.config.Spec

--- a/vendor/github.com/containers/podman/v5/libpod/container_config.go
+++ b/vendor/github.com/containers/podman/v5/libpod/container_config.go
@@ -416,13 +416,16 @@ type ContainerMiscConfig struct {
 	// HealthCheckOnFailureAction defines an action to take once the container turns unhealthy.
 	HealthCheckOnFailureAction define.HealthCheckOnFailureAction `json:"healthcheck_on_failure_action"`
 	// HealthLogDestination defines the destination where the log is stored
-	HealthLogDestination string `json:"healthLogDestination,omitempty"`
+	// Nil value means the default value (local).
+	HealthLogDestination *string `json:"healthLogDestination,omitempty"`
 	// HealthMaxLogCount is maximum number of attempts in the HealthCheck log file.
 	// ('0' value means an infinite number of attempts in the log file)
-	HealthMaxLogCount uint `json:"healthMaxLogCount,omitempty"`
+	// Nil value means the default value (5).
+	HealthMaxLogCount *uint `json:"healthMaxLogCount,omitempty"`
 	// HealthMaxLogSize is the maximum length in characters of stored HealthCheck log
 	// ("0" value means an infinite log length)
-	HealthMaxLogSize uint `json:"healthMaxLogSize,omitempty"`
+	// Nil value means the default value (500).
+	HealthMaxLogSize *uint `json:"healthMaxLogSize,omitempty"`
 	// StartupHealthCheckConfig is the configuration of the startup
 	// healthcheck for the container. This will run before the regular HC
 	// runs, and when it passes the regular HC will be activated.

--- a/vendor/github.com/containers/podman/v5/libpod/container_inspect.go
+++ b/vendor/github.com/containers/podman/v5/libpod/container_inspect.go
@@ -437,11 +437,11 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 
 	ctrConfig.HealthcheckOnFailureAction = c.config.HealthCheckOnFailureAction.String()
 
-	ctrConfig.HealthLogDestination = c.config.HealthLogDestination
+	ctrConfig.HealthLogDestination = c.HealthCheckLogDestination()
 
-	ctrConfig.HealthMaxLogCount = c.config.HealthMaxLogCount
+	ctrConfig.HealthMaxLogCount = c.HealthCheckMaxLogCount()
 
-	ctrConfig.HealthMaxLogSize = c.config.HealthMaxLogSize
+	ctrConfig.HealthMaxLogSize = c.HealthCheckMaxLogSize()
 
 	ctrConfig.CreateCommand = c.config.CreateCommand
 

--- a/vendor/github.com/containers/podman/v5/libpod/container_internal_common.go
+++ b/vendor/github.com/containers/podman/v5/libpod/container_internal_common.go
@@ -2916,6 +2916,10 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 	vol.lock.Lock()
 	defer vol.lock.Unlock()
 
+	return c.fixVolumePermissionsUnlocked(v, vol)
+}
+
+func (c *Container) fixVolumePermissionsUnlocked(v *ContainerNamedVolume, vol *Volume) error {
 	// The volume may need a copy-up. Check the state.
 	if err := vol.update(); err != nil {
 		return err

--- a/vendor/github.com/containers/podman/v5/libpod/define/exec_codes.go
+++ b/vendor/github.com/containers/podman/v5/libpod/define/exec_codes.go
@@ -46,6 +46,7 @@ func ExitCode(err error) int {
 	e := strings.ToLower(err.Error())
 	logrus.Debugf("ExitCode msg: %q", e)
 	if strings.Contains(e, "not found") ||
+		strings.Contains(e, "executable path is empty") ||
 		strings.Contains(e, "no such file") {
 		return ExecErrorCodeNotFound
 	}

--- a/vendor/github.com/containers/podman/v5/libpod/events.go
+++ b/vendor/github.com/containers/podman/v5/libpod/events.go
@@ -49,7 +49,7 @@ func (c *Container) newContainerEventWithInspectData(status events.Status, healt
 	e.Image = c.config.RootfsImageName
 	e.Type = events.Container
 	e.HealthStatus = healthCheckResult.Status
-	if c.config.HealthLogDestination == define.HealthCheckEventsLoggerDestination {
+	if c.HealthCheckLogDestination() == define.HealthCheckEventsLoggerDestination {
 		if len(healthCheckResult.Log) > 0 {
 			logData, err := json.Marshal(healthCheckResult.Log[len(healthCheckResult.Log)-1])
 			if err != nil {

--- a/vendor/github.com/containers/podman/v5/libpod/healthcheck.go
+++ b/vendor/github.com/containers/podman/v5/libpod/healthcheck.go
@@ -136,8 +136,8 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	}
 
 	eventLog := output.String()
-	if c.config.HealthMaxLogSize != 0 && len(eventLog) > int(c.config.HealthMaxLogSize) {
-		eventLog = eventLog[:c.config.HealthMaxLogSize]
+	if c.HealthCheckMaxLogSize() != 0 && len(eventLog) > int(c.HealthCheckMaxLogSize()) {
+		eventLog = eventLog[:c.HealthCheckMaxLogSize()]
 	}
 
 	if timeEnd.Sub(timeStart) > c.HealthCheckConfig().Timeout {
@@ -150,7 +150,7 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 
 	healthCheckResult, err := c.updateHealthCheckLog(hcl, inStartPeriod, isStartup)
 	if err != nil {
-		return hcResult, "", fmt.Errorf("unable to update health check log %s for %s: %w", c.config.HealthLogDestination, c.ID(), err)
+		return hcResult, "", fmt.Errorf("unable to update health check log %s for %s: %w", c.getHealthCheckLogDestination(), c.ID(), err)
 	}
 
 	// Write HC event with appropriate status as the last thing before we
@@ -404,7 +404,7 @@ func (c *Container) updateHealthCheckLog(hcl define.HealthCheckLog, inStartPerio
 		}
 	}
 	healthCheck.Log = append(healthCheck.Log, hcl)
-	if c.config.HealthMaxLogCount != 0 && len(healthCheck.Log) > int(c.config.HealthMaxLogCount) {
+	if c.HealthCheckMaxLogCount() != 0 && len(healthCheck.Log) > int(c.HealthCheckMaxLogCount()) {
 		healthCheck.Log = healthCheck.Log[1:]
 	}
 	return healthCheck, c.writeHealthCheckLog(healthCheck)
@@ -420,11 +420,11 @@ func (c *Container) witeToFileHealthCheckResults(path string, result define.Heal
 
 func (c *Container) getHealthCheckLogDestination() string {
 	var destination string
-	switch c.config.HealthLogDestination {
+	switch c.HealthCheckLogDestination() {
 	case define.DefaultHealthCheckLocalDestination, define.HealthCheckEventsLoggerDestination, "":
 		destination = filepath.Join(filepath.Dir(c.state.RunDir), "healthcheck.log")
 	default:
-		destination = filepath.Join(c.config.HealthLogDestination, c.ID()+"-healthcheck.log")
+		destination = filepath.Join(c.HealthCheckLogDestination(), c.ID()+"-healthcheck.log")
 	}
 	return destination
 }

--- a/vendor/github.com/containers/podman/v5/libpod/oci.go
+++ b/vendor/github.com/containers/podman/v5/libpod/oci.go
@@ -153,6 +153,14 @@ type OCIRuntime interface { //nolint:interfacebloat
 	// This is the path to that file for a given container.
 	OOMFilePath(ctr *Container) (string, error)
 
+	// PersistDirectoryPath is the path to a container's persist directory.
+	// Not all OCI runtime implementations will have a persist directory.
+	// If they do, it may contain files such as the exit file and the OOM
+	// file.
+	// If the directory does not exist, the empty string and no error should
+	// be returned.
+	PersistDirectoryPath(ctr *Container) (string, error)
+
 	// RuntimeInfo returns verbose information about the runtime.
 	RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeInfo, error)
 

--- a/vendor/github.com/containers/podman/v5/libpod/oci_conmon_common.go
+++ b/vendor/github.com/containers/podman/v5/libpod/oci_conmon_common.go
@@ -862,6 +862,11 @@ func (r *ConmonOCIRuntime) OOMFilePath(ctr *Container) (string, error) {
 	return filepath.Join(r.persistDir, ctr.ID(), "oom"), nil
 }
 
+// PersistDirectoryPath is the path to the container's persist directory.
+func (r *ConmonOCIRuntime) PersistDirectoryPath(ctr *Container) (string, error) {
+	return filepath.Join(r.persistDir, ctr.ID()), nil
+}
+
 // RuntimeInfo provides information on the runtime.
 func (r *ConmonOCIRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeInfo, error) {
 	runtimePackage := version.Package(r.path)

--- a/vendor/github.com/containers/podman/v5/libpod/oci_conmon_linux.go
+++ b/vendor/github.com/containers/podman/v5/libpod/oci_conmon_linux.go
@@ -89,14 +89,16 @@ func (r *ConmonOCIRuntime) createRootlessContainer(ctr *Container, restoreOption
 					}
 				}
 
-				// do not propagate the bind mount on the parent mount namespace
-				if err := unix.Mount("", parentMount, "", unix.MS_SLAVE, ""); err != nil {
-					return 0, fmt.Errorf("failed to make %s slave: %w", parentMount, err)
-				}
-
 				// bind mount the containers' mount path to the path where the OCI runtime expects it to be
-				if err := unix.Mount(ctr.state.Mountpoint, rootPath, "", unix.MS_BIND, ""); err != nil {
-					return 0, fmt.Errorf("failed to bind mount %s to %s: %w", ctr.state.Mountpoint, rootPath, err)
+				// if the container is already mounted at the expected path, do not cover the mountpoint.
+				if filepath.Clean(ctr.state.Mountpoint) != filepath.Clean(rootPath) {
+					// do not propagate the bind mount on the parent mount namespace
+					if err := unix.Mount("", parentMount, "", unix.MS_SLAVE, ""); err != nil {
+						return 0, fmt.Errorf("failed to make %s slave: %w", parentMount, err)
+					}
+					if err := unix.Mount(ctr.state.Mountpoint, rootPath, "", unix.MS_BIND, ""); err != nil {
+						return 0, fmt.Errorf("failed to bind mount %s to %s: %w", ctr.state.Mountpoint, rootPath, err)
+					}
 				}
 
 				if isShared {

--- a/vendor/github.com/containers/podman/v5/libpod/oci_missing.go
+++ b/vendor/github.com/containers/podman/v5/libpod/oci_missing.go
@@ -226,6 +226,12 @@ func (r *MissingRuntime) OOMFilePath(ctr *Container) (string, error) {
 	return filepath.Join(r.persistDir, ctr.ID(), "oom"), nil
 }
 
+// PersistDirectoryPath is the path to the container's persist directory.
+// It may include files like the exit file and OOM file.
+func (r *MissingRuntime) PersistDirectoryPath(ctr *Container) (string, error) {
+	return filepath.Join(r.persistDir, ctr.ID()), nil
+}
+
 // RuntimeInfo returns information on the missing runtime
 func (r *MissingRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeInfo, error) {
 	ocirt := define.OCIRuntimeInfo{

--- a/vendor/github.com/containers/podman/v5/libpod/oci_util.go
+++ b/vendor/github.com/containers/podman/v5/libpod/oci_util.go
@@ -152,7 +152,7 @@ func getOCIRuntimeError(name, runtimeMsg string) error {
 		}
 		return fmt.Errorf("%s: %s: %w", name, strings.Trim(errStr, "\n"), define.ErrOCIRuntimePermissionDenied)
 	}
-	if match := regexp.MustCompile("(?i).*executable file not found in.*|.*no such file or directory.*").FindString(runtimeMsg); match != "" {
+	if match := regexp.MustCompile("(?i).*executable file not found in.*|.*no such file or directory.*|.*open executable.*").FindString(runtimeMsg); match != "" {
 		errStr := match
 		if includeFullOutput {
 			errStr = runtimeMsg

--- a/vendor/github.com/containers/podman/v5/libpod/options.go
+++ b/vendor/github.com/containers/podman/v5/libpod/options.go
@@ -1536,7 +1536,7 @@ func WithHealthCheckLogDestination(destination string) CtrCreateOption {
 		if err != nil {
 			return err
 		}
-		ctr.config.HealthLogDestination = dest
+		ctr.config.HealthLogDestination = &dest
 		return nil
 	}
 }
@@ -1547,7 +1547,7 @@ func WithHealthCheckMaxLogCount(maxLogCount uint) CtrCreateOption {
 		if ctr.valid {
 			return define.ErrCtrFinalized
 		}
-		ctr.config.HealthMaxLogCount = maxLogCount
+		ctr.config.HealthMaxLogCount = &maxLogCount
 		return nil
 	}
 }
@@ -1558,7 +1558,7 @@ func WithHealthCheckMaxLogSize(maxLogSize uint) CtrCreateOption {
 		if ctr.valid {
 			return define.ErrCtrFinalized
 		}
-		ctr.config.HealthMaxLogSize = maxLogSize
+		ctr.config.HealthMaxLogSize = &maxLogSize
 		return nil
 	}
 }

--- a/vendor/github.com/containers/podman/v5/pkg/domain/entities/pods.go
+++ b/vendor/github.com/containers/podman/v5/pkg/domain/entities/pods.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	commonFlag "github.com/containers/common/pkg/flag"
+	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/containers/podman/v5/pkg/util"
@@ -275,9 +276,12 @@ type ContainerCreateOptions struct {
 
 func NewInfraContainerCreateOptions() ContainerCreateOptions {
 	options := ContainerCreateOptions{
-		IsInfra:          true,
-		ImageVolume:      "anonymous",
-		MemorySwappiness: -1,
+		IsInfra:              true,
+		ImageVolume:          "anonymous",
+		MemorySwappiness:     -1,
+		HealthLogDestination: define.DefaultHealthCheckLocalDestination,
+		HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
+		HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
 	}
 	return options
 }

--- a/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/artifact.go
+++ b/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/artifact.go
@@ -63,12 +63,18 @@ func (ir *ImageEngine) ArtifactPull(ctx context.Context, name string, opts entit
 	pullOptions.CertDirPath = opts.CertDirPath
 	pullOptions.Username = opts.Username
 	pullOptions.Password = opts.Password
-	// pullOptions.Architecture = opts.Arch
 	pullOptions.SignaturePolicyPath = opts.SignaturePolicyPath
 	pullOptions.InsecureSkipTLSVerify = opts.InsecureSkipTLSVerify
 	pullOptions.Writer = opts.Writer
 	pullOptions.OciDecryptConfig = opts.OciDecryptConfig
 	pullOptions.MaxRetries = opts.MaxRetries
+	if opts.RetryDelay != "" {
+		duration, err := time.ParseDuration(opts.RetryDelay)
+		if err != nil {
+			return nil, err
+		}
+		pullOptions.RetryDelay = &duration
+	}
 
 	if !opts.Quiet && pullOptions.Writer == nil {
 		pullOptions.Writer = os.Stderr

--- a/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/containers.go
+++ b/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/containers.go
@@ -1760,10 +1760,6 @@ func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts enti
 		spec.Name = generate.CheckName(ic.Libpod, n, true)
 	}
 
-	spec.HealthLogDestination = define.DefaultHealthCheckLocalDestination
-	spec.HealthMaxLogCount = define.DefaultHealthMaxLogCount
-	spec.HealthMaxLogSize = define.DefaultHealthMaxLogSize
-
 	rtSpec, spec, opts, err := generate.MakeContainer(context.Background(), ic.Libpod, spec, true, c)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/generate.go
+++ b/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/generate.go
@@ -59,7 +59,12 @@ func (ic *ContainerEngine) GenerateSpec(ctx context.Context, opts *entities.Gene
 	} else if p, err := ic.Libpod.LookupPod(opts.ID); err == nil {
 		pspec = &specgen.PodSpecGenerator{}
 		pspec.Name = p.Name()
-		_, err := generateUtils.PodConfigToSpec(ic.Libpod, pspec, &entities.ContainerCreateOptions{}, opts.ID)
+		_, err := generateUtils.PodConfigToSpec(ic.Libpod, pspec,
+			&entities.ContainerCreateOptions{
+				HealthLogDestination: define.DefaultHealthCheckLocalDestination,
+				HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
+				HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
+			}, opts.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/play.go
+++ b/vendor/github.com/containers/podman/v5/pkg/domain/infra/abi/play.go
@@ -283,6 +283,19 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 	var configMaps []v1.ConfigMap
 
 	ranContainers := false
+	// set the ranContainers bool to true if at least one container was successfully started.
+	setRanContainers := func(r *entities.PlayKubeReport) {
+		if !ranContainers {
+			for _, p := range r.Pods {
+				// If the list of container errors is less then the total number of pod containers then we know it didn't start.
+				if len(p.ContainerErrors) < len(p.Containers)+len(p.InitContainers) {
+					ranContainers = true
+					break
+				}
+			}
+		}
+	}
+
 	// FIXME: both, the service container and the proxies, should ideally
 	// be _state_ of an object. The Kube code below is quite Spaghetti-code
 	// which we should refactor at some point to make it easier to extend
@@ -364,7 +377,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 
 			report.Pods = append(report.Pods, r.Pods...)
 			validKinds++
-			ranContainers = true
+			setRanContainers(r)
 		case "DaemonSet":
 			var daemonSetYAML v1apps.DaemonSet
 
@@ -380,7 +393,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 
 			report.Pods = append(report.Pods, r.Pods...)
 			validKinds++
-			ranContainers = true
+			setRanContainers(r)
 		case "Deployment":
 			var deploymentYAML v1apps.Deployment
 
@@ -396,7 +409,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 
 			report.Pods = append(report.Pods, r.Pods...)
 			validKinds++
-			ranContainers = true
+			setRanContainers(r)
 		case "Job":
 			var jobYAML v1.Job
 
@@ -412,7 +425,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 
 			report.Pods = append(report.Pods, r.Pods...)
 			validKinds++
-			ranContainers = true
+			setRanContainers(r)
 		case "PersistentVolumeClaim":
 			var pvcYAML v1.PersistentVolumeClaim
 
@@ -473,10 +486,14 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 		return nil, fmt.Errorf("YAML document does not contain any supported kube kind")
 	}
 
+	if !options.ServiceContainer {
+		return report, nil
+	}
+
 	// If we started containers along with a service container, we are
 	// running inside a systemd unit and need to set the main PID.
 
-	if options.ServiceContainer && ranContainers {
+	if ranContainers {
 		switch len(notifyProxies) {
 		case 0: // Optimization for containers/podman/issues/17345
 			// No container needs sdnotify, so we can mark the
@@ -509,6 +526,12 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 		}
 
 		report.ServiceContainerID = serviceContainer.ID()
+	} else if serviceContainer != nil {
+		// No containers started, make sure to stop the service container.
+		// Note because the pods still do exists and are not removed by default we cannot remove it.
+		if err := serviceContainer.StopWithTimeout(0); err != nil {
+			logrus.Errorf("Failed to stop service container: %v", err)
+		}
 	}
 
 	return report, nil
@@ -715,9 +738,6 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 	}
 
 	p := specgen.NewPodSpecGenerator()
-	if err != nil {
-		return nil, nil, err
-	}
 
 	p, err = entities.ToPodSpecGen(*p, &podOpt)
 	if err != nil {
@@ -1143,7 +1163,6 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		}
 		for id, err := range podStartErrors {
 			playKubePod.ContainerErrors = append(playKubePod.ContainerErrors, fmt.Errorf("starting container %s: %w", id, err).Error())
-			fmt.Println(playKubePod.ContainerErrors)
 		}
 
 		// Wait for each proxy to receive a READY message. Use a wait
@@ -1633,7 +1652,7 @@ func getBuildFile(imageName string, cwd string) (string, error) {
 	// If the error is not because the file does not exist, take
 	// a mulligan and try Dockerfile.  If that also fails, return that
 	// error
-	if err != nil && !os.IsNotExist(err) {
+	if !errors.Is(err, os.ErrNotExist) {
 		logrus.Error(err.Error())
 	}
 
@@ -1643,7 +1662,7 @@ func getBuildFile(imageName string, cwd string) (string, error) {
 		return dockerfilePath, nil
 	}
 	// Strike two
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return "", nil
 	}
 	return "", err

--- a/vendor/github.com/containers/podman/v5/pkg/specgen/generate/container.go
+++ b/vendor/github.com/containers/podman/v5/pkg/specgen/generate/container.go
@@ -444,9 +444,23 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 		}
 	}
 
-	specg.HealthLogDestination = conf.HealthLogDestination
-	specg.HealthMaxLogCount = conf.HealthMaxLogCount
-	specg.HealthMaxLogSize = conf.HealthMaxLogSize
+	if conf.HealthLogDestination != nil {
+		specg.HealthLogDestination = *conf.HealthLogDestination
+	} else {
+		specg.HealthLogDestination = define.DefaultHealthCheckLocalDestination
+	}
+
+	if conf.HealthMaxLogCount != nil {
+		specg.HealthMaxLogCount = *conf.HealthMaxLogCount
+	} else {
+		specg.HealthMaxLogCount = define.DefaultHealthMaxLogCount
+	}
+
+	if conf.HealthMaxLogSize != nil {
+		specg.HealthMaxLogSize = *conf.HealthMaxLogSize
+	} else {
+		specg.HealthMaxLogSize = define.DefaultHealthMaxLogSize
+	}
 
 	specg.IDMappings = &conf.IDMappings
 	specg.ContainerCreateCommand = conf.CreateCommand

--- a/vendor/github.com/containers/podman/v5/pkg/specgen/generate/kube/kube.go
+++ b/vendor/github.com/containers/podman/v5/pkg/specgen/generate/kube/kube.go
@@ -404,6 +404,10 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		s.Annotations[define.InspectAnnotationInit] = init
 	}
 
+	s.HealthLogDestination = define.DefaultHealthCheckLocalDestination
+	s.HealthMaxLogCount = define.DefaultHealthMaxLogCount
+	s.HealthMaxLogSize = define.DefaultHealthMaxLogSize
+
 	if publishAll, ok := opts.Annotations[define.InspectAnnotationPublishAll+"/"+opts.Container.Name]; ok {
 		if opts.IsInfra {
 			publishAllAsBool, err := strconv.ParseBool(publishAll)
@@ -417,9 +421,6 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	}
 
 	s.Annotations[define.KubeHealthCheckAnnotation] = "true"
-	s.HealthLogDestination = define.DefaultHealthCheckLocalDestination
-	s.HealthMaxLogCount = define.DefaultHealthMaxLogCount
-	s.HealthMaxLogSize = define.DefaultHealthMaxLogSize
 
 	// Environment Variables
 	envs := map[string]string{}

--- a/vendor/github.com/containers/podman/v5/pkg/specgen/generate/pod_create.go
+++ b/vendor/github.com/containers/podman/v5/pkg/specgen/generate/pod_create.go
@@ -86,11 +86,6 @@ func MakePod(p *entities.PodSpec, rt *libpod.Runtime) (_ *libpod.Pod, finalErr e
 		p.PodSpecGen.InfraContainerSpec.ResourceLimits = nil
 		p.PodSpecGen.InfraContainerSpec.WeightDevice = nil
 
-		// Set default for HealthCheck
-		p.PodSpecGen.InfraContainerSpec.HealthLogDestination = define.DefaultHealthCheckLocalDestination
-		p.PodSpecGen.InfraContainerSpec.HealthMaxLogCount = define.DefaultHealthMaxLogCount
-		p.PodSpecGen.InfraContainerSpec.HealthMaxLogSize = define.DefaultHealthMaxLogSize
-
 		rtSpec, spec, opts, err := MakeContainer(context.Background(), rt, p.PodSpecGen.InfraContainerSpec, false, nil)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/containers/podman/v5/pkg/specgen/specgen.go
+++ b/vendor/github.com/containers/podman/v5/pkg/specgen/specgen.go
@@ -602,14 +602,17 @@ type ContainerHealthCheckConfig struct {
 	// Requires that HealthConfig be set.
 	// Optional.
 	StartupHealthConfig *define.StartupHealthCheck `json:"startupHealthConfig,omitempty"`
-	// HealthLogDestination defines the destination where the log is stored
-	HealthLogDestination string `json:"healthLogDestination,omitempty"`
+	// HealthLogDestination defines the destination where the log is stored.
+	// TODO (6.0): In next major release convert it to pointer and use omitempty
+	HealthLogDestination string `json:"healthLogDestination"`
 	// HealthMaxLogCount is maximum number of attempts in the HealthCheck log file.
-	// ('0' value means an infinite number of attempts in the log file)
-	HealthMaxLogCount uint `json:"healthMaxLogCount,omitempty"`
+	// ('0' value means an infinite number of attempts in the log file).
+	// TODO (6.0): In next major release convert it to pointer and use omitempty
+	HealthMaxLogCount uint `json:"healthMaxLogCount"`
 	// HealthMaxLogSize is the maximum length in characters of stored HealthCheck log
-	// ("0" value means an infinite log length)
-	HealthMaxLogSize uint `json:"healthMaxLogSize,omitempty"`
+	// ("0" value means an infinite log length).
+	// TODO (6.0): In next major release convert it to pointer and use omitempty
+	HealthMaxLogSize uint `json:"healthMaxLogSize"`
 }
 
 // SpecGenerator creates an OCI spec and Libpod configuration options to create

--- a/vendor/github.com/containers/podman/v5/version/rawversion/version.go
+++ b/vendor/github.com/containers/podman/v5/version/rawversion/version.go
@@ -7,4 +7,4 @@ package rawversion
 //
 // NOTE: remember to bump the version at the top of the top-level README.md
 // file when this is bumped.
-const RawVersion = "5.4.0"
+const RawVersion = "5.4.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -148,7 +148,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.5.1
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.39.1
+# github.com/containers/buildah v1.39.4
 ## explicit; go 1.22.8
 github.com/containers/buildah
 github.com/containers/buildah/bind
@@ -349,7 +349,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d
 ## explicit; go 1.22.8
 github.com/containers/podman/v5/cmd/podman/parse
 github.com/containers/podman/v5/cmd/podman/registry
@@ -1451,5 +1451,5 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250424130403-85a1f4d420f1
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
This updates the podman code to 5.4.2 with the macadam changes.

## Summary by Sourcery

Update Go dependencies.

Build:
- Update the replaced `podman` module to commit `f5cb7f8c7a1d` on the `cfergeau/podman` fork.
- Update the indirect `buildah` dependency to `v1.39.4`.
- Refresh vendored dependencies.