### PR TITLE
rm: Don’t print "success" message if removal is cancelled

### DIFF
--- a/.github/workflows/macadam.yml
+++ b/.github/workflows/macadam.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-        - oldstable
-        - stable
+        - '1.23.8'
+        - '1.24.2'
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: make cross
       - name: Upload macadam artifact
-        if: matrix.go == 'stable'
+        if: matrix.go == '1.23.8'
         uses: actions/upload-artifact@v4
         with:
           name: macadam binaries
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'oldstable'
+          go-version: '1.23.8'
       - name: Test
         run: make test
 
@@ -76,6 +76,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'oldstable'
+          go-version: '1.23.8'
       - name: Run 'make check'
         run: make check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       if: matrix.os != 'macos-latest'
       run: |
         make cross-non-darwin
-    
+
     - name: Build macOS Installer
       if: matrix.os == 'macos-latest'
       run: |
@@ -53,7 +53,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Download all artifacts
       uses: actions/download-artifact@v4
       with:
@@ -70,7 +70,7 @@ jobs:
         cd artifacts
 
         # Upload Linux and Windows binaries
-        cd macadam-binaries-ubuntu-22.04          
+        cd macadam-binaries-ubuntu-22.04
         sha256sum * >> ../sha256sums
         gh release upload "$RELEASE_TAG" *
 

--- a/go.mod
+++ b/go.mod
@@ -219,6 +219,6 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250507090918-181a5233cf8e
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d h1:l2D868gDqdOCzTBLj0ROB8ZTjvuyGMy+46p2I5zj6Y0=
-github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d/go.mod h1:p4TndXjITbW8STQps3U16QQdsZHl3Os2uQEl8Sy7XPM=
+github.com/cfergeau/podman/v5 v5.0.0-20250507090918-181a5233cf8e h1:gMFr6chg3xxy4N/J2YtM6NfXLLoeBmSdI+cAjy5gBgs=
+github.com/cfergeau/podman/v5 v5.0.0-20250507090918-181a5233cf8e/go.mod h1:p4TndXjITbW8STQps3U16QQdsZHl3Os2uQEl8Sy7XPM=
 github.com/checkpoint-restore/checkpointctl v1.3.0 h1:bNz5b6s+lxFdG5ZGDba3qSkBtXDDTCG2494dfAbQJ4E=
 github.com/checkpoint-restore/checkpointctl v1.3.0/go.mod h1:dqZH4wDvbjnsqFGK2LdUDk21yFQ1dCAtzgRMlG44KDM=
 github.com/checkpoint-restore/go-criu/v7 v7.2.0 h1:qGiWA4App1gGlEfIJ68WR9jbezV9J7yZdjzglezcqKo=

--- a/pkg/machinedriver/driver.go
+++ b/pkg/machinedriver/driver.go
@@ -18,6 +18,7 @@ package macadam
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -518,6 +519,10 @@ func (d *Driver) RemoveWithOptions(opts machine.RemoveOptions) error {
 	}
 
 	if err := shim.Remove(d.vmConfig, d.vmProvider, dirs, opts); err != nil {
+		/* don’t print anything if the user cancelled the removal */
+		if errors.Is(err, shim.ErrRemoveUserCancelled) {
+			return nil
+		}
 		return err
 	}
 	//newMachineEvent(events.Remove, events.Event{Name: vmName})

--- a/vendor/github.com/containers/podman/v5/pkg/machine/qemu/command/command.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/qemu/command/command.go
@@ -79,15 +79,19 @@ func (q *QemuCmd) SetUSBHostPassthrough(usbs []define.USBConfig) {
 }
 
 // SetSerialPort adds a serial port to the machine for readiness
-func (q *QemuCmd) SetSerialPort(readySocket, vmPidFile define.VMFile, name string) {
+func (q *QemuCmd) SetSerialPort(readySocket define.VMFile, name string) {
 	*q = append(*q,
 		"-device", "virtio-serial",
 		// qemu needs to establish the long name; other connections can use the symlink'd
 		// Note both id and chardev start with an extra "a" because qemu requires that it
 		// starts with a letter but users can also use numbers
 		"-chardev", "socket,path="+readySocket.GetPath()+",server=on,wait=off,id=a"+name+"_ready",
-		"-device", "virtserialport,chardev=a"+name+"_ready"+",name=org.fedoraproject.port.0",
-		"-pidfile", vmPidFile.GetPath())
+		"-device", "virtserialport,chardev=a"+name+"_ready"+",name=org.fedoraproject.port.0")
+}
+
+// SetPidFile sets the path where to write QEMU PID
+func (q *QemuCmd) SetPidFile(vmPidFile define.VMFile) {
+	*q = append(*q, "-pidfile", vmPidFile.GetPath())
 }
 
 // SetBootableImage specifies the image the machine will use to boot

--- a/vendor/github.com/containers/podman/v5/pkg/machine/qemu/stubber.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/qemu/stubber.go
@@ -93,9 +93,10 @@ func (q *QEMUStubber) setQEMUCommandLine(mc *vmconfigs.MachineConfig) error {
 		if err != nil {
 			return err
 		}
-		q.Command.SetSerialPort(*readySocket, *mc.QEMUHypervisor.QEMUPidPath, mc.Name)
+		q.Command.SetSerialPort(*readySocket, mc.Name)
 	}
 
+	q.Command.SetPidFile(*mc.QEMUHypervisor.QEMUPidPath)
 	q.Command.SetUSBHostPassthrough(mc.Resources.USBs)
 
 	return nil

--- a/vendor/github.com/containers/podman/v5/pkg/machine/shim/host.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/shim/host.go
@@ -24,6 +24,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var ErrRemoveUserCancelled = errors.New("user cancelled the removal operation")
+
 // List is done at the host level to allow for a *possible* future where
 // more than one provider is used
 func List(vmstubbers []vmconfigs.VMProvider, _ machine.ListOptions) ([]*machine.ListResponse, error) {
@@ -697,7 +699,7 @@ func Remove(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineD
 			return err
 		}
 		if strings.ToLower(answer)[0] != 'y' {
-			return nil
+			return ErrRemoveUserCancelled
 		}
 	}
 

--- a/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/shim/networking.go
@@ -203,8 +203,10 @@ func reassignSSHPort(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 	}
 
 	mc.SSH.Port = newPort
-	if err := connection.UpdateConnectionPairPort(mc.Name, newPort, mc.HostUser.UID, mc.SSH.RemoteUsername, mc.SSH.IdentityPath); err != nil {
-		return fmt.Errorf("could not update remote connection configuration: %w", err)
+	if mc.Capabilities.GetForwardSockets() {
+		if err := connection.UpdateConnectionPairPort(mc.Name, newPort, mc.HostUser.UID, mc.SSH.RemoteUsername, mc.SSH.IdentityPath); err != nil {
+			return fmt.Errorf("could not update remote connection configuration: %w", err)
+		}
 	}
 
 	// Write updated port back

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250507090918-181a5233cf8e
 ## explicit; go 1.22.8
 github.com/containers/podman/v5/cmd/podman/parse
 github.com/containers/podman/v5/cmd/podman/registry
@@ -1451,5 +1451,5 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250429093108-f5cb7f8c7a1d
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250507090918-181a5233cf8e
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
When running `macadam rm <machine-name>`, you'll sometimes get an
`Are you sure you want to continue? [y/N] message.` However, when choosing
`N`, it'll still show the
`Machine <machine-name> removed successfully` message, even though the 
machine was not deleted.

This commit removes the message when the user chose `N`.

This fixes https://github.com/crc-org/macadam/issues/171

## Summary by Sourcery

Bug Fixes:
- Prevent displaying 'Machine removed successfully' message when user cancels machine removal