### PR TITLE
Fix build with go 1.23.9 and 1.24.3

### DIFF
--- a/.github/workflows/macadam.yml
+++ b/.github/workflows/macadam.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-        - '1.23.8'
-        - '1.24.2'
+        - oldstable
+        - stable
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: make cross
       - name: Upload macadam artifact
-        if: matrix.go == '1.23.8'
+        if: matrix.go == 'stable'
         uses: actions/upload-artifact@v4
         with:
           name: macadam binaries
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.8'
+          go-version: 'oldstable'
       - name: Test
         run: make test
 
@@ -76,6 +76,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.8'
+          go-version: 'oldstable'
       - name: Run 'make check'
         run: make check

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-plugins-helpers v0.0.0-20240701071450-45e2431495c8 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/ebitengine/purego v0.8.2 // indirect
+	github.com/ebitengine/purego v0.8.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/fsouza/go-dockerclient v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/docker/go-plugins-helpers v0.0.0-20240701071450-45e2431495c8 h1:IMfrF
 github.com/docker/go-plugins-helpers v0.0.0-20240701071450-45e2431495c8/go.mod h1:LFyLie6XcDbyKGeVK6bHe+9aJTYCxWLBg5IrJZOaXKA=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
-github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.8.3 h1:K+0AjQp63JEZTEMZiwsI9g0+hAMNohwUOtY0RPGexmc=
+github.com/ebitengine/purego v0.8.3/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/vendor/github.com/ebitengine/purego/dlfcn.go
+++ b/vendor/github.com/ebitengine/purego/dlfcn.go
@@ -83,17 +83,17 @@ func loadSymbol(handle uintptr, name string) (uintptr, error) {
 // appear to work if you link directly to the C function on darwin arm64.
 
 //go:linkname dlopen dlopen
-var dlopen uintptr
+var dlopen uint8
 var dlopenABI0 = uintptr(unsafe.Pointer(&dlopen))
 
 //go:linkname dlsym dlsym
-var dlsym uintptr
+var dlsym uint8
 var dlsymABI0 = uintptr(unsafe.Pointer(&dlsym))
 
 //go:linkname dlclose dlclose
-var dlclose uintptr
+var dlclose uint8
 var dlcloseABI0 = uintptr(unsafe.Pointer(&dlclose))
 
 //go:linkname dlerror dlerror
-var dlerror uintptr
+var dlerror uint8
 var dlerrorABI0 = uintptr(unsafe.Pointer(&dlerror))

--- a/vendor/github.com/ebitengine/purego/dlfcn_darwin.go
+++ b/vendor/github.com/ebitengine/purego/dlfcn_darwin.go
@@ -17,8 +17,3 @@ const (
 //go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlclose dlclose "/usr/lib/libSystem.B.dylib"
-
-//go:cgo_import_dynamic purego_dlopen dlopen "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlclose dlclose "/usr/lib/libSystem.B.dylib"

--- a/vendor/github.com/ebitengine/purego/internal/fakecgo/symbols.go
+++ b/vendor/github.com/ebitengine/purego/internal/fakecgo/symbols.go
@@ -121,81 +121,81 @@ func pthread_setspecific(key pthread_key_t, value unsafe.Pointer) int32 {
 }
 
 //go:linkname _malloc _malloc
-var _malloc uintptr
+var _malloc uint8
 var mallocABI0 = uintptr(unsafe.Pointer(&_malloc))
 
 //go:linkname _free _free
-var _free uintptr
+var _free uint8
 var freeABI0 = uintptr(unsafe.Pointer(&_free))
 
 //go:linkname _setenv _setenv
-var _setenv uintptr
+var _setenv uint8
 var setenvABI0 = uintptr(unsafe.Pointer(&_setenv))
 
 //go:linkname _unsetenv _unsetenv
-var _unsetenv uintptr
+var _unsetenv uint8
 var unsetenvABI0 = uintptr(unsafe.Pointer(&_unsetenv))
 
 //go:linkname _sigfillset _sigfillset
-var _sigfillset uintptr
+var _sigfillset uint8
 var sigfillsetABI0 = uintptr(unsafe.Pointer(&_sigfillset))
 
 //go:linkname _nanosleep _nanosleep
-var _nanosleep uintptr
+var _nanosleep uint8
 var nanosleepABI0 = uintptr(unsafe.Pointer(&_nanosleep))
 
 //go:linkname _abort _abort
-var _abort uintptr
+var _abort uint8
 var abortABI0 = uintptr(unsafe.Pointer(&_abort))
 
 //go:linkname _pthread_attr_init _pthread_attr_init
-var _pthread_attr_init uintptr
+var _pthread_attr_init uint8
 var pthread_attr_initABI0 = uintptr(unsafe.Pointer(&_pthread_attr_init))
 
 //go:linkname _pthread_create _pthread_create
-var _pthread_create uintptr
+var _pthread_create uint8
 var pthread_createABI0 = uintptr(unsafe.Pointer(&_pthread_create))
 
 //go:linkname _pthread_detach _pthread_detach
-var _pthread_detach uintptr
+var _pthread_detach uint8
 var pthread_detachABI0 = uintptr(unsafe.Pointer(&_pthread_detach))
 
 //go:linkname _pthread_sigmask _pthread_sigmask
-var _pthread_sigmask uintptr
+var _pthread_sigmask uint8
 var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
 
 //go:linkname _pthread_self _pthread_self
-var _pthread_self uintptr
+var _pthread_self uint8
 var pthread_selfABI0 = uintptr(unsafe.Pointer(&_pthread_self))
 
 //go:linkname _pthread_get_stacksize_np _pthread_get_stacksize_np
-var _pthread_get_stacksize_np uintptr
+var _pthread_get_stacksize_np uint8
 var pthread_get_stacksize_npABI0 = uintptr(unsafe.Pointer(&_pthread_get_stacksize_np))
 
 //go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
-var _pthread_attr_getstacksize uintptr
+var _pthread_attr_getstacksize uint8
 var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
 
 //go:linkname _pthread_attr_setstacksize _pthread_attr_setstacksize
-var _pthread_attr_setstacksize uintptr
+var _pthread_attr_setstacksize uint8
 var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
 
 //go:linkname _pthread_attr_destroy _pthread_attr_destroy
-var _pthread_attr_destroy uintptr
+var _pthread_attr_destroy uint8
 var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
 
 //go:linkname _pthread_mutex_lock _pthread_mutex_lock
-var _pthread_mutex_lock uintptr
+var _pthread_mutex_lock uint8
 var pthread_mutex_lockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_lock))
 
 //go:linkname _pthread_mutex_unlock _pthread_mutex_unlock
-var _pthread_mutex_unlock uintptr
+var _pthread_mutex_unlock uint8
 var pthread_mutex_unlockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_unlock))
 
 //go:linkname _pthread_cond_broadcast _pthread_cond_broadcast
-var _pthread_cond_broadcast uintptr
+var _pthread_cond_broadcast uint8
 var pthread_cond_broadcastABI0 = uintptr(unsafe.Pointer(&_pthread_cond_broadcast))
 
 //go:linkname _pthread_setspecific _pthread_setspecific
-var _pthread_setspecific uintptr
+var _pthread_setspecific uint8
 var pthread_setspecificABI0 = uintptr(unsafe.Pointer(&_pthread_setspecific))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -638,7 +638,7 @@ github.com/docker/go-plugins-helpers/volume
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/ebitengine/purego v0.8.2
+# github.com/ebitengine/purego v0.8.3
 ## explicit; go 1.18
 github.com/ebitengine/purego
 github.com/ebitengine/purego/internal/cgo


### PR DESCRIPTION
There was an issue with github.com/ebitengine/purego older than v0.8.3

## Summary by Sourcery

Fix build compatibility with Go 1.23.9 and 1.24.3 by bumping the purego dependency and updating CI workflows to use supported Go version labels.

Bug Fixes:
- Bump github.com/ebitengine/purego dependency from v0.8.2 to v0.8.3 to resolve build issues with older versions.

CI:
- Update GitHub Actions workflow matrix to use ‘oldstable’ and ‘stable’ labels instead of specific Go versions.
- Adjust setup-go and artifact upload steps to reference the new version labels in CI jobs.