### PR TITLE
Add human-readable format to "macadam list"

### DIFF
--- a/cmd/macadam/common/completion.go
+++ b/cmd/macadam/common/completion.go
@@ -1,6 +1,12 @@
 package common
 
-import "github.com/spf13/cobra"
+import (
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 var LogLevels = []string{"trace", "debug", "info", "warn", "warning", "error", "fatal", "panic"}
 
@@ -8,4 +14,217 @@ var LogLevels = []string{"trace", "debug", "info", "warn", "warning", "error", "
 // -> "trace", "debug", "info", "warn", "error", "fatal", "panic"
 func AutocompleteLogLevel(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return LogLevels, cobra.ShellCompDirectiveNoFileComp
+}
+
+type formatSuggestion struct {
+	fieldname string
+	suffix    string
+}
+
+func convertFormatSuggestions(suggestions []formatSuggestion) []string {
+	completions := make([]string, 0, len(suggestions))
+	for _, f := range suggestions {
+		completions = append(completions, f.fieldname+f.suffix)
+	}
+	return completions
+}
+
+// AutocompleteFormat - Autocomplete json or a given struct to use for a go template.
+// The input can be nil, In this case only json will be autocompleted.
+// This function will only work for pointer to structs other types are not supported.
+// When "{{." is typed the field and method names of the given struct will be completed.
+// This also works recursive for nested structs.
+func AutocompleteFormat(o interface{}) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// this function provides shell completion for go templates
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// autocomplete json when nothing or json is typed
+		// gocritic complains about the argument order but this is correct in this case
+		//nolint:gocritic
+		if strings.HasPrefix("json", toComplete) {
+			return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		// no input struct we cannot provide completion return nothing
+		if o == nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		// toComplete could look like this: {{ .Config }} {{ .Field.F
+		// 1. split the template variable delimiter
+		vars := strings.Split(toComplete, "{{")
+		if len(vars) == 1 {
+			// no variables return no completion
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// clean the spaces from the last var
+		field := strings.Split(vars[len(vars)-1], " ")
+		// split this into it struct field names
+		fields := strings.Split(field[len(field)-1], ".")
+		f := reflect.ValueOf(o)
+		if f.Kind() != reflect.Ptr {
+			// We panic here to make sure that all callers pass the value by reference.
+			// If someone passes a by value then all podman commands will panic since
+			// this function is run at init time.
+			panic("AutocompleteFormat: passed value must be a pointer to a struct")
+		}
+		for i := 1; i < len(fields); i++ {
+			// last field get all names to suggest
+			if i == len(fields)-1 {
+				suggestions := getStructFields(f, fields[i])
+				// add the current toComplete value in front so that the shell can complete this correctly
+				toCompArr := strings.Split(toComplete, ".")
+				toCompArr[len(toCompArr)-1] = ""
+				toComplete = strings.Join(toCompArr, ".")
+				return prefixSlice(toComplete, convertFormatSuggestions(suggestions)), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+			}
+
+			// first follow pointer and create element when it is nil
+			f = actualReflectValue(f)
+			switch f.Kind() {
+			case reflect.Struct:
+				for j := 0; j < f.NumField(); j++ {
+					field := f.Type().Field(j)
+					// ok this is a bit weird but when we have an embedded nil struct
+					// calling FieldByName on a name which is present on this struct will panic
+					// Therefore we have to init them (non nil ptr), https://github.com/containers/podman/issues/14223
+					if field.Anonymous && f.Field(j).Type().Kind() == reflect.Ptr {
+						f.Field(j).Set(reflect.New(f.Field(j).Type().Elem()))
+					}
+				}
+				// set the next struct field
+				f = f.FieldByName(fields[i])
+			case reflect.Map:
+				rtype := f.Type().Elem()
+				if rtype.Kind() == reflect.Ptr {
+					rtype = rtype.Elem()
+				}
+				f = reflect.New(rtype)
+			case reflect.Func:
+				if f.Type().NumOut() != 1 {
+					// unsupported type return nothing
+					return nil, cobra.ShellCompDirectiveNoFileComp
+				}
+				f = reflect.New(f.Type().Out(0))
+			default:
+				// unsupported type return nothing
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// actualReflectValue takes the value,
+// if it is pointer it will dereference it and when it is nil,
+// it will create a new value from it
+func actualReflectValue(f reflect.Value) reflect.Value {
+	// follow the pointer first
+	if f.Kind() == reflect.Ptr {
+		// if the pointer is nil we create a new value from the elements type
+		// this allows us to follow nil pointers and get the actual type
+		if f.IsNil() {
+			f = reflect.New(f.Type().Elem())
+		}
+		f = f.Elem()
+	}
+	return f
+}
+
+// getStructFields reads all struct field names and method names and returns them.
+func getStructFields(f reflect.Value, prefix string) []formatSuggestion {
+	var suggestions []formatSuggestion
+	if f.IsValid() {
+		suggestions = append(suggestions, getMethodNames(f, prefix)...)
+	}
+
+	f = actualReflectValue(f)
+	// we only support structs
+	if f.Kind() != reflect.Struct {
+		return suggestions
+	}
+
+	var anonymous []formatSuggestion
+	// loop over all field names
+	for j := 0; j < f.NumField(); j++ {
+		field := f.Type().Field(j)
+		// check if struct field is not exported, templates only use exported fields
+		// PkgPath is always empty for exported fields
+		if field.PkgPath != "" {
+			continue
+		}
+		fname := field.Name
+		suffix := "}}"
+		kind := field.Type.Kind()
+		if kind == reflect.Ptr {
+			// make sure to read the actual type when it is a pointer
+			kind = field.Type.Elem().Kind()
+		}
+		// when we have a nested struct do not append braces instead append a dot
+		if kind == reflect.Struct || kind == reflect.Map {
+			suffix = "."
+		}
+		// if field is anonymous add the child fields as well
+		if field.Anonymous {
+			anonymous = append(anonymous, getStructFields(f.Field(j), prefix)...)
+		}
+		if strings.HasPrefix(fname, prefix) {
+			// add field name with suffix
+			suggestions = append(suggestions, formatSuggestion{fieldname: fname, suffix: suffix})
+		}
+	}
+outer:
+	for _, ano := range anonymous {
+		// we should only add anonymous child fields if they are not already present.
+		for _, sug := range suggestions {
+			if ano.fieldname == sug.fieldname {
+				continue outer
+			}
+		}
+		suggestions = append(suggestions, ano)
+	}
+	return suggestions
+}
+
+func getMethodNames(f reflect.Value, prefix string) []formatSuggestion {
+	suggestions := make([]formatSuggestion, 0, f.NumMethod())
+	for j := 0; j < f.NumMethod(); j++ {
+		method := f.Type().Method(j)
+		// in a template we can only run functions with one return value
+		if method.Func.Type().NumOut() != 1 {
+			continue
+		}
+		// when we have a nested struct do not append braces instead append a dot
+		kind := method.Func.Type().Out(0).Kind()
+		suffix := "}}"
+		if kind == reflect.Struct || kind == reflect.Map {
+			suffix = "."
+		}
+		// From a template user's POV it is not important whether they use a struct field or method.
+		// They only notice the difference when the function requires arguments.
+		// So let's be nice and let the user know that this method requires arguments via the help text.
+		// Note since this is actually a method on a type the first argument is always fix so we should skip it.
+		num := method.Func.Type().NumIn() - 1
+		if num > 0 {
+			// everything after tab will the completion scripts show as help when enabled
+			// overwrite the suffix because it expects the args
+			suffix = "\tThis is a function and requires " + strconv.Itoa(num) + " argument"
+			if num > 1 {
+				// add plural s
+				suffix += "s"
+			}
+		}
+		fname := method.Name
+		if strings.HasPrefix(fname, prefix) {
+			// add method name with closing braces
+			suggestions = append(suggestions, formatSuggestion{fieldname: fname, suffix: suffix})
+		}
+	}
+	return suggestions
+}
+
+func prefixSlice(pre string, slice []string) []string {
+	for i := range slice {
+		slice[i] = pre + slice[i]
+	}
+	return slice
 }

--- a/cmd/macadam/list.go
+++ b/cmd/macadam/list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"time"
 
@@ -84,6 +85,21 @@ func list(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Sort by last run
+	sort.Slice(listDrivers, func(i, j int) bool {
+		lhs_vm := listDrivers[i].GetVmConfig()
+		rhs_vm := listDrivers[j].GetVmConfig()
+		return lhs_vm.LastUp.After(rhs_vm.LastUp)
+	})
+	// Bring currently running machines to top
+	sort.Slice(listDrivers, func(i, j int) bool {
+		vmState, err := listDrivers[i].GetState()
+		if err != nil {
+			return false
+		}
+		return vmState == state.Running
+	})
 
 	if report.IsJSON(listFlag.format) {
 		machineReporter := toMachineFormat(listDrivers)

--- a/cmd/macadam/list.go
+++ b/cmd/macadam/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	provider2 "github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/crc-org/macadam/cmd/macadam/common"
 	"github.com/crc-org/macadam/cmd/macadam/registry"
 	macadam "github.com/crc-org/macadam/pkg/machinedriver"
 	"github.com/crc-org/machine/libmachine/state"
@@ -66,6 +67,8 @@ func init() {
 	flags := lsCmd.Flags()
 	formatFlagName := "format"
 	flags.StringVar(&listFlag.format, formatFlagName, "{{range .}}{{.Name}}\t{{.VMType}}\t{{.Created}}\t{{.LastUp}}\t{{.CPUs}}\t{{.Memory}}\t{{.DiskSize}}\n{{end -}}", "Format volume output using JSON or a Go template")
+	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(ListReporter{}))
+
 	flags.BoolVarP(&listFlag.noHeading, "noheading", "n", false, "Do not print headers")
 	flags.BoolVarP(&listFlag.quiet, "quiet", "q", false, "Show only machine names")
 }

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-plugins-helpers v0.0.0-20240701071450-45e2431495c8 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
+	github.com/docker/go-units v0.5.0
 	github.com/ebitengine/purego v0.8.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect

--- a/vendor/github.com/containers/common/pkg/report/camelcase/LICENSE.md
+++ b/vendor/github.com/containers/common/pkg/report/camelcase/LICENSE.md
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/containers/common/pkg/report/camelcase/README.md
+++ b/vendor/github.com/containers/common/pkg/report/camelcase/README.md
@@ -1,0 +1,58 @@
+# CamelCase [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/camelcase) [![Build Status](http://img.shields.io/travis/fatih/camelcase.svg?style=flat-square)](https://travis-ci.org/fatih/camelcase)
+
+CamelCase is a Golang (Go) package to split the words of a camelcase type
+string into a slice of words. It can be used to convert a camelcase word (lower
+or upper case) into any type of word.
+
+## Splitting rules:
+
+1. If string is not valid UTF-8, return it without splitting as
+   single item array.
+2. Assign all unicode characters into one of 4 sets: lower case
+   letters, upper case letters, numbers, and all other characters.
+3. Iterate through characters of string, introducing splits
+   between adjacent characters that belong to different sets.
+4. Iterate through array of split strings, and if a given string
+   is upper case:
+   * if subsequent string is lower case:
+     * move last character of upper case string to beginning of
+       lower case string
+
+## Install
+
+```bash
+go get github.com/fatih/camelcase
+```
+
+## Usage and examples
+
+```go
+split := camelcase.Split("GolangPackage")
+
+fmt.Println(split[0], split[1]) // prints: "Golang", "Package"
+```
+
+Both lower camel case and upper camel case are supported. For more info please
+check: [http://en.wikipedia.org/wiki/CamelCase](http://en.wikipedia.org/wiki/CamelCase)
+
+Below are some example cases:
+
+```
+"" =>                     []
+"lowercase" =>            ["lowercase"]
+"Class" =>                ["Class"]
+"MyClass" =>              ["My", "Class"]
+"MyC" =>                  ["My", "C"]
+"HTML" =>                 ["HTML"]
+"PDFLoader" =>            ["PDF", "Loader"]
+"AString" =>              ["A", "String"]
+"SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+"vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+"GL11Version" =>          ["GL", "11", "Version"]
+"99Bottles" =>            ["99", "Bottles"]
+"May5" =>                 ["May", "5"]
+"BFG9000" =>              ["BFG", "9000"]
+"BöseÜberraschung" =>     ["Böse", "Überraschung"]
+"Two  spaces" =>          ["Two", "  ", "spaces"]
+"BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+```

--- a/vendor/github.com/containers/common/pkg/report/camelcase/camelcase.go
+++ b/vendor/github.com/containers/common/pkg/report/camelcase/camelcase.go
@@ -1,0 +1,90 @@
+// Package camelcase is a micro package to split the words of a camelcase type
+// string into a slice of words.
+package camelcase
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Split splits the camelcase word and returns a list of words. It also
+// supports digits. Both lower camel case and upper camel case are supported.
+// For more info please check: http://en.wikipedia.org/wiki/CamelCase
+//
+// Examples
+//
+//	"" =>                     [""]
+//	"lowercase" =>            ["lowercase"]
+//	"Class" =>                ["Class"]
+//	"MyClass" =>              ["My", "Class"]
+//	"MyC" =>                  ["My", "C"]
+//	"HTML" =>                 ["HTML"]
+//	"PDFLoader" =>            ["PDF", "Loader"]
+//	"AString" =>              ["A", "String"]
+//	"SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+//	"vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+//	"GL11Version" =>          ["GL", "11", "Version"]
+//	"99Bottles" =>            ["99", "Bottles"]
+//	"May5" =>                 ["May", "5"]
+//	"BFG9000" =>              ["BFG", "9000"]
+//	"BöseÜberraschung" =>     ["Böse", "Überraschung"]
+//	"Two  spaces" =>          ["Two", "  ", "spaces"]
+//	"BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+//
+// Splitting rules
+//
+//  1. If string is not valid UTF-8, return it without splitting as
+//     single item array.
+//  2. Assign all unicode characters into one of 4 sets: lower case
+//     letters, upper case letters, numbers, and all other characters.
+//  3. Iterate through characters of string, introducing splits
+//     between adjacent characters that belong to different sets.
+//  4. Iterate through array of split strings, and if a given string
+//     is upper case:
+//     if subsequent string is lower case:
+//     move last character of upper case string to beginning of
+//     lower case string
+func Split(src string) (entries []string) {
+	// don't split invalid utf8
+	if !utf8.ValidString(src) {
+		return []string{src}
+	}
+	entries = []string{}
+	var runes [][]rune
+	var class, lastClass int
+	// split into fields based on class of unicode character
+	for _, r := range src {
+		switch {
+		case unicode.IsLower(r):
+			class = 1
+		case unicode.IsUpper(r):
+			class = 2
+		case unicode.IsDigit(r):
+			class = 3
+		default:
+			class = 4
+		}
+		if class == lastClass {
+			runes[len(runes)-1] = append(runes[len(runes)-1], r)
+		} else {
+			runes = append(runes, []rune{r})
+		}
+		lastClass = class
+	}
+	// handle upper case -> lower case sequences, e.g.
+	// "PDFL", "oader" -> "PDF", "Loader"
+	for i := range len(runes) - 1 {
+		if unicode.IsUpper(runes[i][0]) && unicode.IsLower(runes[i+1][0]) {
+			runes[i+1] = append([]rune{runes[i][len(runes[i])-1]}, runes[i+1]...)
+			runes[i] = runes[i][:len(runes[i])-1]
+		}
+	}
+	// construct []string from results
+	for _, s := range runes {
+		if len(s) > 0 {
+			entries = append(entries, string(s))
+		}
+	}
+
+	return entries
+}

--- a/vendor/github.com/containers/common/pkg/report/doc.go
+++ b/vendor/github.com/containers/common/pkg/report/doc.go
@@ -1,0 +1,76 @@
+/*
+Package report provides helper structs/methods/funcs for formatting output
+
+# Examples
+
+To format output for an array of structs:
+
+ExamplePodman:
+
+	headers := report.Headers(struct {
+		ID string
+	}{}, nil)
+
+	f := report.New(os.Stdout, "Command Name")
+	f, _ := f.Parse(report.OriginPodman, "{{range .}}{{.ID}}{{end}}")
+	defer f.Flush()
+
+	if f.RenderHeaders {
+		f.Execute(headers)
+	}
+	f.Execute( map[string]string{
+		"ID":"fa85da03b40141899f3af3de6d27852b",
+	})
+
+	// Output:
+	// ID
+	// fa85da03b40141899f3af3de6d27852b
+
+ExampleUser:
+
+	headers := report.Headers(struct {
+		CID string
+	}{}, map[string]string{"CID":"ID"})
+
+	f, _ := report.New(os.Stdout, "Command Name").Parse(report.OriginUser, "table {{.CID}}")
+	defer f.Flush()
+
+	if f.RenderHeaders {
+		t.Execute(t, headers)
+	}
+	t.Execute(t,map[string]string{
+		"CID":"fa85da03b40141899f3af3de6d27852b",
+	})
+
+	// Output:
+	// ID
+	// fa85da03b40141899f3af3de6d27852b
+
+Helpers:
+
+	if report.IsJSON(cmd.Flag("format").Value.String()) {
+		... process JSON and output
+	}
+
+	if report.HasTable(cmd.Flag("format").Value.String()) {
+		... "table" keyword prefix in format text
+	}
+
+# Template Functions
+
+The following template functions are added to the template when parsed:
+  - join  strings.Join, {{join .Field separator}}
+  - json encode field as JSON {{ json .Field }}
+  - lower strings.ToLower {{ .Field | lower }}
+  - pad add spaces as prefix and suffix {{ pad . 2 2 }}
+  - split strings.Split {{ .Field | split }}
+  - title strings.Title {{ .Field | title }}
+  - truncate limit field length {{ truncate . 10 }}
+  - upper strings.ToUpper {{ .Field | upper }}
+
+report.Funcs() may be used to add additional template functions.
+Adding an existing function will replace that function for the life of that template.
+
+Note: Your code should not ignore errors
+*/
+package report

--- a/vendor/github.com/containers/common/pkg/report/formatter.go
+++ b/vendor/github.com/containers/common/pkg/report/formatter.go
@@ -1,0 +1,171 @@
+package report
+
+import (
+	"io"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+)
+
+// Flusher is the interface that wraps the Flush method.
+type Flusher interface {
+	Flush() error
+}
+
+// NopFlusher represents a type which flush operation is nop.
+type NopFlusher struct{}
+
+// Flush is a nop operation.
+func (f *NopFlusher) Flush() (err error) { return }
+
+type Origin int
+
+const (
+	OriginUnknown Origin = iota
+	OriginPodman
+	OriginUser
+)
+
+func (o Origin) String() string {
+	switch o {
+	case OriginPodman:
+		return "OriginPodman"
+	case OriginUser:
+		return "OriginUser"
+	default:
+		return "OriginUnknown"
+	}
+}
+
+// Formatter holds the configured Writer and parsed Template, additional state fields are
+// maintained to assist in the podman command report writing.
+type Formatter struct {
+	Origin        Origin             // Source of go template. OriginUser or OriginPodman
+	RenderHeaders bool               // Hint, default behavior for given template is to include headers
+	RenderTable   bool               // Does template have "table" keyword
+	flusher       Flusher            // Flush any buffered formatted output
+	template      *template.Template // Go text/template for formatting output
+	text          string             // value of canonical template after processing
+	writer        io.Writer          // Destination for formatted output
+}
+
+// stringsCutPrefix is equivalent to Go 1.20’s strings.CutPrefix.
+// Replace this function with a direct call to the standard library after we update to Go 1.20.
+func stringsCutPrefix(s, prefix string) (string, bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return s, false
+	}
+	return s[len(prefix):], true
+}
+
+// Parse parses golang template returning a formatter
+//
+//   - OriginPodman implies text is a template from podman code. Output will
+//     be filtered through a tabwriter.
+//
+//   - OriginUser implies text is a template from a user. If template includes
+//     keyword "table" output will be filtered through a tabwriter.
+func (f *Formatter) Parse(origin Origin, text string) (*Formatter, error) {
+	f.Origin = origin
+
+	// docker tries to be smart and replaces \n with the actual newline character.
+	// For compat we do the same but this will break formats such as '{{printf "\n"}}'
+	// To be backwards compatible with the previous behavior we try to replace and
+	// parse the template. If it fails use the original text and parse again.
+	var normText string
+	textWithoutTable, hasTable := stringsCutPrefix(text, "table ")
+	switch {
+	case hasTable:
+		f.RenderTable = true
+		normText = "{{range .}}" + NormalizeFormat(text) + "{{end -}}"
+		text = "{{range .}}" + textWithoutTable + "{{end -}}"
+	case OriginUser == origin:
+		normText = EnforceRange(NormalizeFormat(text))
+		text = EnforceRange(text)
+	default:
+		normText = NormalizeFormat(text)
+	}
+
+	if f.RenderTable || origin == OriginPodman {
+		tw := tabwriter.NewWriter(f.writer, 12, 2, 2, ' ', tabwriter.StripEscape)
+		f.writer = tw
+		f.flusher = tw
+		f.RenderHeaders = true
+	}
+
+	tmpl, err := f.template.Funcs(template.FuncMap(DefaultFuncs)).Parse(normText)
+	if err != nil {
+		tmpl, err = f.template.Funcs(template.FuncMap(DefaultFuncs)).Parse(text)
+		f.template = tmpl
+		f.text = text
+		return f, err
+	}
+	f.text = normText
+	f.template = tmpl
+	return f, nil
+}
+
+// Funcs adds the elements of the argument map to the template's function map.
+// A default template function will be replaced if there is a key collision.
+func (f *Formatter) Funcs(funcMap template.FuncMap) *Formatter {
+	m := make(template.FuncMap, len(DefaultFuncs)+len(funcMap))
+	for k, v := range DefaultFuncs {
+		m[k] = v
+	}
+	for k, v := range funcMap {
+		m[k] = v
+	}
+	f.template = f.template.Funcs(funcMap)
+	return f
+}
+
+// Init either resets the given tabwriter with new values or wraps w in tabwriter with given values
+func (f *Formatter) Init(w io.Writer, minwidth, tabwidth, padding int, padchar byte, flags uint) *Formatter {
+	flags |= tabwriter.StripEscape
+
+	if tw, ok := f.writer.(*tabwriter.Writer); ok {
+		tw = tw.Init(w, minwidth, tabwidth, padding, padchar, flags)
+		f.writer = tw
+		f.flusher = tw
+	} else {
+		tw = tabwriter.NewWriter(w, minwidth, tabwidth, padding, padchar, flags)
+		f.writer = tw
+		f.flusher = tw
+	}
+	return f
+}
+
+// Execute applies a parsed template to the specified data object,
+// and writes the output to Formatter.Writer.
+func (f *Formatter) Execute(data any) error {
+	return f.template.Execute(f.writer, data)
+}
+
+// Flush should be called after the last call to Write to ensure
+// that any data buffered in the Formatter is written to output. Any
+// incomplete escape sequence at the end is considered
+// complete for formatting purposes.
+func (f *Formatter) Flush() error {
+	// Indirection is required here to prevent caller from having to know when
+	// value of Flusher may be changed.
+	return f.flusher.Flush()
+}
+
+// Writer returns the embedded io.Writer from Formatter
+func (f *Formatter) Writer() io.Writer {
+	return f.writer
+}
+
+// New allocates a new, undefined Formatter with the given name and Writer
+func New(output io.Writer, name string) *Formatter {
+	f := new(Formatter)
+
+	f.flusher = new(NopFlusher)
+	if flusher, ok := output.(Flusher); ok {
+		f.flusher = flusher
+	}
+
+	f.template = template.New(name)
+	f.writer = output
+	return f
+}

--- a/vendor/github.com/containers/common/pkg/report/template.go
+++ b/vendor/github.com/containers/common/pkg/report/template.go
@@ -1,0 +1,176 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"text/template"
+
+	"github.com/containers/common/pkg/report/camelcase"
+	"github.com/containers/storage/pkg/regexp"
+)
+
+// Template embeds template.Template to add functionality to methods
+type Template struct {
+	*template.Template
+	isTable bool
+}
+
+// FuncMap is aliased from template.FuncMap
+type FuncMap template.FuncMap
+
+// tableReplacer will remove 'table ' prefix and clean up tabs
+var tableReplacer = strings.NewReplacer(
+	"table ", "",
+	`\t`, "\t",
+	" ", "\t",
+	`\n`, "\n",
+)
+
+// escapedReplacer will clean up escaped characters from CLI
+var escapedReplacer = strings.NewReplacer(
+	`\t`, "\t",
+	`\n`, "\n",
+)
+
+var DefaultFuncs = FuncMap{
+	"join": strings.Join,
+	"json": func(v any) string {
+		buf := new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		_ = enc.Encode(v)
+		// Remove the trailing new line added by the encoder
+		return strings.TrimSpace(buf.String())
+	},
+	"lower":    strings.ToLower,
+	"pad":      padWithSpace,
+	"split":    strings.Split,
+	"title":    strings.Title, //nolint:staticcheck
+	"truncate": truncateWithLength,
+	"upper":    strings.ToUpper,
+}
+
+// NormalizeFormat reads given go template format provided by CLI and munges it into what we need
+func NormalizeFormat(format string) string {
+	var f string
+	// two replacers used so we only remove the prefix keyword `table`
+	if strings.HasPrefix(format, "table ") {
+		f = tableReplacer.Replace(format)
+	} else {
+		f = escapedReplacer.Replace(format)
+	}
+
+	if !strings.HasSuffix(f, "\n") {
+		f += "\n"
+	}
+	return f
+}
+
+// padWithSpace adds spaces*prefix and spaces*suffix to the input when it is non-empty
+func padWithSpace(source string, prefix, suffix int) string {
+	if source == "" {
+		return source
+	}
+	return strings.Repeat(" ", prefix) + source + strings.Repeat(" ", suffix)
+}
+
+// truncateWithLength truncates the source string up to the length provided by the input
+func truncateWithLength(source string, length int) string {
+	if len(source) < length {
+		return source
+	}
+	return source[:length]
+}
+
+// Headers queries the interface for field names.
+// Array of map is returned to support range templates
+// Note: unexported fields can be supported by adding field to overrides
+// Note: It is left to the developer to write out said headers
+//
+//	Podman commands use the general rules of:
+//	1) unchanged --format includes headers
+//	2) --format '{{.ID}"        # no headers
+//	3) --format 'table {{.ID}}' # includes headers
+func Headers(object any, overrides map[string]string) []map[string]string {
+	value := reflect.ValueOf(object)
+	if value.Kind() == reflect.Ptr {
+		value = value.Elem()
+	}
+
+	// Column header will be field name upper-cased.
+	headers := make(map[string]string, value.NumField())
+	for i := range value.Type().NumField() {
+		field := value.Type().Field(i)
+		// Recurse to find field names from promoted structs
+		if field.Type.Kind() == reflect.Struct && field.Anonymous {
+			h := Headers(reflect.New(field.Type).Interface(), nil)
+			for k, v := range h[0] {
+				headers[k] = v
+			}
+			continue
+		}
+		name := strings.Join(camelcase.Split(field.Name), " ")
+		headers[field.Name] = strings.ToUpper(name)
+	}
+
+	if len(overrides) > 0 {
+		// Override column header as provided
+		for k, v := range overrides {
+			headers[k] = strings.ToUpper(v)
+		}
+	}
+	return []map[string]string{headers}
+}
+
+// NewTemplate creates a new template object
+func NewTemplate(name string) *Template {
+	return &Template{Template: template.New(name).Funcs(template.FuncMap(DefaultFuncs))}
+}
+
+// Parse parses text as a template body for t
+func (t *Template) Parse(text string) (*Template, error) {
+	if strings.HasPrefix(text, "table ") {
+		t.isTable = true
+		text = "{{range .}}" + NormalizeFormat(text) + "{{end -}}"
+	} else {
+		text = NormalizeFormat(text)
+	}
+
+	tt, err := t.Template.Funcs(template.FuncMap(DefaultFuncs)).Parse(text)
+	return &Template{tt, t.isTable}, err
+}
+
+// Funcs adds the elements of the argument map to the template's function map.
+// A default template function will be replace if there is a key collision.
+func (t *Template) Funcs(funcMap FuncMap) *Template {
+	m := make(FuncMap)
+	for k, v := range DefaultFuncs {
+		m[k] = v
+	}
+	for k, v := range funcMap {
+		m[k] = v
+	}
+	return &Template{Template: t.Template.Funcs(template.FuncMap(m)), isTable: t.isTable}
+}
+
+// IsTable returns true if format string defines a "table"
+func (t *Template) IsTable() bool {
+	return t.isTable
+}
+
+var rangeRegex = regexp.Delayed(`(?s){{\s*range\s*\.\s*}}.*{{\s*end\s*-?\s*}}`)
+
+// EnforceRange ensures that the format string contains a range
+func EnforceRange(format string) string {
+	if !rangeRegex.MatchString(format) {
+		return "{{range .}}" + format + "{{end -}}"
+	}
+	return format
+}
+
+// HasTable returns whether the format is a table
+func HasTable(format string) bool {
+	return strings.HasPrefix(format, "table ")
+}

--- a/vendor/github.com/containers/common/pkg/report/validate.go
+++ b/vendor/github.com/containers/common/pkg/report/validate.go
@@ -1,0 +1,18 @@
+package report
+
+import (
+	"github.com/containers/storage/pkg/regexp"
+)
+
+// Check for json, {{json }} and {{ json. }} which are not valid go template,
+// {{json .}} is valid and thus not matched to let the template handle it like docker does.
+var jsonRegex = regexp.Delayed(`^\s*(json|{{\s*json\.?\s*}})\s*$`)
+
+// JSONFormat test CLI --format string to be a JSON request
+//
+//	if report.IsJSON(cmd.Flag("format").Value.String()) {
+//	  ... process JSON and output
+//	}
+func IsJSON(s string) bool {
+	return jsonRegex.MatchString(s)
+}

--- a/vendor/github.com/containers/common/pkg/report/writer.go
+++ b/vendor/github.com/containers/common/pkg/report/writer.go
@@ -1,0 +1,27 @@
+package report
+
+import (
+	"io"
+	"text/tabwriter"
+)
+
+// Writer aliases tabwriter.Writer to provide Podman defaults
+type Writer struct {
+	*tabwriter.Writer
+}
+
+// NewWriter initializes a new report.Writer with given values
+func NewWriter(output io.Writer, minwidth, tabwidth, padding int, padchar byte, flags uint) (*Writer, error) {
+	t := tabwriter.NewWriter(output, minwidth, tabwidth, padding, padchar, flags)
+	return &Writer{t}, nil
+}
+
+// NewWriterDefault initializes a new report.Writer with Podman defaults
+func NewWriterDefault(output io.Writer) (*Writer, error) {
+	return NewWriter(output, 12, 2, 2, ' ', 0)
+}
+
+// Flush any output left in buffers
+func (w *Writer) Flush() error {
+	return w.Writer.Flush()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,6 +222,8 @@ github.com/containers/common/pkg/manifests
 github.com/containers/common/pkg/netns
 github.com/containers/common/pkg/parse
 github.com/containers/common/pkg/password
+github.com/containers/common/pkg/report
+github.com/containers/common/pkg/report/camelcase
 github.com/containers/common/pkg/resize
 github.com/containers/common/pkg/retry
 github.com/containers/common/pkg/rootlessport


### PR DESCRIPTION
It currently displays json by default, which is not really user friendly.
After this PR, the default format is the same as `podman machine list`, but json output can be selected with `--format json`

## Summary by Sourcery

Use a human-readable default format for `macadam list`, introduce header and quiet modes, support JSON or templated output, enable format flag autocompletion, and vendor the reporting library.

New Features:
- Change default output of `macadam list` to a human-readable table format matching Podman’s style
- Add `--noheading` (`-n`) and `--quiet` (`-q`) flags for header suppression and name-only output

Enhancements:
- Allow JSON output via `--format json` while preserving custom Go-template support
- Add shell completion for the `--format` flag with field and method suggestions
- Implement `toHumanFormat` for human-friendly durations and VM status strings

Build:
- Vendor the `containers/common/pkg/report` package and update `github.com/docker/go-units` import