### PR TITLE
add hyperv support

### DIFF
--- a/cmd/macadam/ssh.go
+++ b/cmd/macadam/ssh.go
@@ -116,6 +116,11 @@ func ssh(cmd *cobra.Command, args []string) error {
 		username = mc.SSH.RemoteUsername
 	}
 
-	err = machine.CommonSSHShell(username, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, sshOpts.Args)
+	address := "localhost"
+	if mc.IPAddress != "" {
+		address = mc.IPAddress
+	}
+
+	err = machine.CommonSSHShellWithAddress(username, mc.SSH.IdentityPath, mc.Name, address, mc.SSH.Port, sshOpts.Args)
 	return utils.HandleOSExecError(err)
 }

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/containers/conmon v2.0.20+incompatible // indirect
 	github.com/containers/gvisor-tap-vsock v0.8.6 // indirect
 	github.com/containers/image/v5 v5.36.0 // indirect
-	github.com/containers/libhvee v0.10.0 // indirect
+	github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/luksy v0.0.0-20250217190002-40bd943d93b8 // indirect
 	github.com/containers/ocicrypt v1.2.1 // indirect
@@ -189,6 +189,6 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v1.0.0 // indirect
 )
 
-replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250612142329-e5103c59144d
+replace github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250723135928-052bdcf53a71
 
 replace github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078 h1:KpgRncgq6ZiWDnLe6R58dJjd6QSuU7RDqRrpl11Dxcg=
 github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
-github.com/cfergeau/podman/v5 v5.0.0-20250612142329-e5103c59144d h1:utMe3L8Ttf2fCXwmGnnROW0Q8Qmm66032FHuG225FPk=
-github.com/cfergeau/podman/v5 v5.0.0-20250612142329-e5103c59144d/go.mod h1:zszs7X4vO2jXaXOoWyzHis5j2A+tPqox6ZajhsuKreM=
+github.com/cfergeau/podman/v5 v5.0.0-20250723135928-052bdcf53a71 h1:wCHSVX+W+gjl5vNSM7R5G0j00CbEqaHtMtcK2AJ6P14=
+github.com/cfergeau/podman/v5 v5.0.0-20250723135928-052bdcf53a71/go.mod h1:2T3UnwLW/ujzyCz3vHfabg3jk2Tr33lVNxYotWwSztU=
 github.com/checkpoint-restore/checkpointctl v1.3.0 h1:bNz5b6s+lxFdG5ZGDba3qSkBtXDDTCG2494dfAbQJ4E=
 github.com/checkpoint-restore/checkpointctl v1.3.0/go.mod h1:dqZH4wDvbjnsqFGK2LdUDk21yFQ1dCAtzgRMlG44KDM=
 github.com/checkpoint-restore/go-criu/v7 v7.2.0 h1:qGiWA4App1gGlEfIJ68WR9jbezV9J7yZdjzglezcqKo=
@@ -76,8 +76,8 @@ github.com/containers/gvisor-tap-vsock v0.8.6 h1:9SeAXK+K2o36CtrgYk6zRXbU3zrayjv
 github.com/containers/gvisor-tap-vsock v0.8.6/go.mod h1:+0mtKmm4STeSDnZe+DGnIwN4EH2f7AcWir7PwT28Ti0=
 github.com/containers/image/v5 v5.36.0 h1:Zh+xFcLjRmicnOT5AFPHH/xj+e3s9ojDN/9X2Kx1+Jo=
 github.com/containers/image/v5 v5.36.0/go.mod h1:VZ6cyDHbxZoOt4dklUJ+WNEH9FrgSgfH3qUBYKFlcT0=
-github.com/containers/libhvee v0.10.0 h1:7VLv8keWZpHuGmWvyY4c1mVH5V1JYb1G78VC+8AlrM0=
-github.com/containers/libhvee v0.10.0/go.mod h1:at0h8lRcK5jCKfQgU/e6Io0Mw12F36zRLjXVOXRoDTM=
+github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5 h1:wRVaP8192oHKkQ7hHLm+Dsq+08Mt4GKl4SDF/jhm5Cs=
+github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5/go.mod h1:MLfTB8sW7E2UwQ/WknTHbuiYtNpWCR9XENMhA/hm8h0=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/luksy v0.0.0-20250217190002-40bd943d93b8 h1:hAkmJxAYcNxgv7EsFY9sf1uIYhilYOQqjJ9UzCmYvzY=

--- a/pkg/machinedriver/provider/platform_windows.go
+++ b/pkg/machinedriver/provider/platform_windows.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
+	hypervPkg "github.com/containers/podman/v5/pkg/machine/hyperv"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	wslPkg "github.com/containers/podman/v5/pkg/machine/wsl"
 )
 
 const wsl = "wsl"
+const hyperv = "hyperv"
 
 func GetProviderOrDefault(name string) (vmconfigs.VMProvider, error) {
 	if name == "" {
@@ -17,13 +19,15 @@ func GetProviderOrDefault(name string) (vmconfigs.VMProvider, error) {
 	switch name {
 	case wsl:
 		return new(wslPkg.WSLStubber), nil
+	case hyperv:
+		return new(hypervPkg.HyperVStubber), nil
 	default:
 		return nil, fmt.Errorf("unknown provider `%s`. Valid providers are: %v", name, GetProviders())
 	}
 }
 
 func GetProviders() []string {
-	return []string{wsl}
+	return []string{wsl, hyperv}
 }
 
 func GetDefaultProvider() string {

--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -56,8 +56,8 @@ func checkVfkitVersion() error {
 func checkSupportedProviders(provider vmconfigs.VMProvider) error {
 	vmType := provider.VMType()
 	switch vmType {
-	case define.HyperVVirt, define.LibKrun:
-		return fmt.Errorf("%s VM provider is unsupported, only wsl2 on Windows, vfkit on macOS and qemu on linux are supported", vmType.String())
+	case define.LibKrun:
+		return fmt.Errorf("%s VM provider is unsupported, only wsl2 and hyperv on Windows, vfkit on macOS and qemu on linux are supported", vmType.String())
 	default:
 		return nil
 	}

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
@@ -430,7 +430,7 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 		return err
 	}
 
-	if err := NewDriveSettingsBuilder(systemSettings).
+	builder := NewDriveSettingsBuilder(systemSettings).
 		AddScsiController().
 		AddSyntheticDiskDrive(0).
 		DefineVirtualHardDisk(config.DiskPath, func(vhdss *VirtualHardDiskStorageSettings) {
@@ -438,15 +438,24 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 			// vhdss.IOPSLimit = 5000
 		}).
 		Finish(). // disk
-		Finish(). // drive
-		//AddSyntheticDvdDrive(1).
-		//DefineVirtualDvdDisk(isoFile).
-		//Finish(). // disk
-		//Finish(). // drive
+		Finish()  // drive
+
+	if config.DVDDiskPath != "" {
+		// Add a DVD drive if the DVDDiskPath is set
+		// This is useful for cloud-init or other bootable media
+		builder = builder.
+			AddSyntheticDvdDrive(1).
+			DefineVirtualDvdDisk(config.DVDDiskPath).
+			Finish(). // disk
+			Finish()  // drive
+	}
+
+	if err := builder.
 		Finish(). // controller
 		Complete(); err != nil {
 		return err
 	}
+
 	// Add default network connection
 	if config.Network {
 		if err := NewNetworkSettingsBuilder(systemSettings).

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm_config.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm_config.go
@@ -101,6 +101,9 @@ type HardwareConfig struct {
 	// Network is bool to add a Network Connection to the
 	// default network switch in Microsoft HyperV
 	Network bool
+	// DVDDiskPath is the path to the disk image
+	// that will be used as a DVD drive in the VM (e.g. for cloud-init)
+	DVDDiskPath string
 }
 
 type Statuses struct {

--- a/vendor/github.com/containers/podman/v5/pkg/machine/apple/apple.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/apple/apple.go
@@ -361,13 +361,21 @@ func getFirstBootAppleVMIgnition(mc *vmconfigs.MachineConfig) ([]string, error) 
 }
 
 func getFirstBootAppleVMCloudInit(mc *vmconfigs.MachineConfig) ([]string, error) {
-	// we generate the user-data file
-	userDataFile, err := cloudinit.GenerateUserDataFile(mc)
-	if err != nil {
-		return nil, err
-	}
+	if mc.LibKrunHypervisor == nil {
+		// we generate the user-data file
+		userDataFile, err := cloudinit.GenerateUserDataFile(mc)
+		if err != nil {
+			return nil, err
+		}
 
-	return []string{"--cloud-init", userDataFile}, nil
+		return []string{"--cloud-init", userDataFile}, nil
+	} else {
+		cloudinitISO, err := cloudinit.GenerateISO(mc)
+		if err != nil {
+			return nil, err
+		}
+		return []string{"--device", fmt.Sprintf("virtio-blk,path=%s", cloudinitISO)}, nil
+	}
 }
 
 // CheckProcessRunning checks non blocking if the pid exited

--- a/vendor/github.com/containers/podman/v5/pkg/machine/cloudinit/cloudinit.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/cloudinit/cloudinit.go
@@ -17,7 +17,7 @@ type User struct {
 	Name    string   `yaml:"name"`
 	Sudo    string   `yaml:"sudo"`
 	Shell   string   `yaml:"shell"`
-	Groups  string   `yaml:"groups"`
+	Groups  []string `yaml:"groups"`
 	SSHKeys []string `yaml:"ssh_authorized_keys"`
 }
 
@@ -34,13 +34,11 @@ func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 	userData := UserData{
 		Users: []User{
 			User{
-				Name:   mc.SSH.RemoteUsername,
-				Sudo:   "ALL=(ALL) NOPASSWD:ALL",
-				Shell:  "/bin/bash",
-				Groups: "users",
-				SSHKeys: []string{
-					sshKey,
-				},
+				Name:    mc.SSH.RemoteUsername,
+				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
+				Shell:   "/bin/bash",
+				Groups:  []string{"users"},
+				SSHKeys: []string{sshKey},
 			},
 		},
 	}
@@ -91,6 +89,7 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (string, error) {
 			logrus.Error(err)
 		}
 	}()
+
 	userdata, err := GenerateUserData(mc)
 	if err != nil {
 		return "", nil

--- a/vendor/github.com/containers/podman/v5/pkg/machine/libkrun/stubber.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/libkrun/stubber.go
@@ -39,17 +39,19 @@ func (l *LibKrunStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.Machin
 	}
 	mc.LibKrunHypervisor.KRun.Endpoint = localhostURI + ":" + strconv.Itoa(randPort)
 
-	virtiofsMounts := make([]machine.VirtIoFs, 0, len(mc.Mounts))
-	for _, mnt := range mc.Mounts {
-		virtiofsMounts = append(virtiofsMounts, machine.MountToVirtIOFs(mnt))
-	}
+	if builder != nil {
+		virtiofsMounts := make([]machine.VirtIoFs, 0, len(mc.Mounts))
+		for _, mnt := range mc.Mounts {
+			virtiofsMounts = append(virtiofsMounts, machine.MountToVirtIOFs(mnt))
+		}
 
-	// Populate the ignition file with virtiofs stuff
-	virtIOIgnitionMounts, err := apple.GenerateSystemDFilesForVirtiofsMounts(virtiofsMounts)
-	if err != nil {
-		return err
+		// Populate the ignition file with virtiofs stuff
+		virtIOIgnitionMounts, err := apple.GenerateSystemDFilesForVirtiofsMounts(virtiofsMounts)
+		if err != nil {
+			return err
+		}
+		builder.WithUnit(virtIOIgnitionMounts...)
 	}
-	builder.WithUnit(virtIOIgnitionMounts...)
 
 	return apple.ResizeDisk(mc, mc.Resources.DiskSize)
 }
@@ -123,7 +125,7 @@ func (l *LibKrunStubber) UserModeNetworkEnabled(mc *vmconfigs.MachineConfig) boo
 	return true
 }
 
-func (l *LibKrunStubber) UseProviderNetworkSetup() bool {
+func (l *LibKrunStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return false
 }
 

--- a/vendor/github.com/containers/podman/v5/pkg/machine/qemu/stubber.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/qemu/stubber.go
@@ -44,7 +44,7 @@ func (q *QEMUStubber) UserModeNetworkEnabled(*vmconfigs.MachineConfig) bool {
 	return true
 }
 
-func (q *QEMUStubber) UseProviderNetworkSetup() bool {
+func (q *QEMUStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return false
 }
 

--- a/vendor/github.com/containers/podman/v5/pkg/machine/ssh.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/ssh.go
@@ -17,28 +17,39 @@ import (
 // and a port
 // TODO This should probably be taught about an machineconfig to reduce input
 func CommonSSH(username, identityPath, name string, sshPort int, inputArgs []string) error {
-	return commonBuiltinSSH(username, identityPath, name, sshPort, inputArgs, true, os.Stdin)
+	return commonBuiltinSSH(username, identityPath, name, "localhost", sshPort, inputArgs, true, os.Stdin)
+}
+
+func CommonSSHShellWithAddress(username, identityPath, name, address string, sshPort int, inputArgs []string) error {
+	if address == "" {
+		address = "localhost"
+	}
+	return commonNativeSSH(username, identityPath, name, address, sshPort, inputArgs, os.Stdin)
 }
 
 func CommonSSHShell(username, identityPath, name string, sshPort int, inputArgs []string) error {
-	return commonNativeSSH(username, identityPath, name, sshPort, inputArgs, os.Stdin)
+	return CommonSSHShellWithAddress(username, identityPath, name, "localhost", sshPort, inputArgs)
 }
 
 func CommonSSHSilent(username, identityPath, name string, sshPort int, inputArgs []string) error {
-	return commonBuiltinSSH(username, identityPath, name, sshPort, inputArgs, false, nil)
+	return commonBuiltinSSH(username, identityPath, name, "localhost", sshPort, inputArgs, false, nil)
 }
 
 func CommonSSHWithStdin(username, identityPath, name string, sshPort int, inputArgs []string, stdin io.Reader) error {
-	return commonBuiltinSSH(username, identityPath, name, sshPort, inputArgs, true, stdin)
+	return commonBuiltinSSH(username, identityPath, name, "localhost", sshPort, inputArgs, true, stdin)
 }
 
-func commonBuiltinSSH(username, identityPath, name string, sshPort int, inputArgs []string, passOutput bool, stdin io.Reader) error {
+func CommonSSHSilentWithAddress(username, identityPath, name, address string, sshPort int, inputArgs []string) error {
+	return commonBuiltinSSH(username, identityPath, name, address, sshPort, inputArgs, false, nil)
+}
+
+func commonBuiltinSSH(username, identityPath, name, address string, sshPort int, inputArgs []string, passOutput bool, stdin io.Reader) error {
 	config, err := createConfig(username, identityPath)
 	if err != nil {
 		return err
 	}
 
-	client, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%d", sshPort), config)
+	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", address, sshPort), config)
 	if err != nil {
 		return err
 	}
@@ -109,8 +120,8 @@ func createConfig(user string, identityPath string) (*ssh.ClientConfig, error) {
 	}, nil
 }
 
-func commonNativeSSH(username, identityPath, name string, sshPort int, inputArgs []string, stdin io.Reader) error {
-	sshDestination := username + "@localhost"
+func commonNativeSSH(username, identityPath, name, address string, sshPort int, inputArgs []string, stdin io.Reader) error {
+	sshDestination := username + "@" + address
 	port := strconv.Itoa(sshPort)
 	interactive := true
 

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config.go
@@ -58,6 +58,7 @@ type MachineConfig struct {
 
 	CloudInit    bool
 	Capabilities *define.MachineCapabilities
+	IPAddress    string
 }
 
 type machineImage interface { //nolint:unused
@@ -99,7 +100,7 @@ type VMProvider interface { //nolint:interfacebloat
 	StopHostNetworking(mc *MachineConfig, vmType define.VMType) error
 	VMType() define.VMType
 	UserModeNetworkEnabled(mc *MachineConfig) bool
-	UseProviderNetworkSetup() bool
+	UseProviderNetworkSetup(mc *MachineConfig) bool
 	RequireExclusiveActive() bool
 	UpdateSSHPort(mc *MachineConfig, port int) error
 	GetRosetta(mc *MachineConfig) (bool, error)

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config_windows.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/config_windows.go
@@ -7,6 +7,8 @@ import (
 )
 
 type HyperVConfig struct {
+	// Uses usermode networking
+	UserModeNetworking bool
 	// ReadyVSock is the pipeline for the guest to alert the host
 	// it is running
 	ReadyVsock vsock.HVSockRegistryEntry

--- a/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/vmconfigs/machine.go
@@ -320,6 +320,13 @@ func (mc *MachineConfig) ConnectionInfo(vmtype define.VMType) (*define.VMFile, *
 	return socket, getPipe(mc.Name), err
 }
 
+func (mc *MachineConfig) GetAddress() string {
+	if mc.IPAddress != "" {
+		return mc.IPAddress
+	}
+	return "localhost"
+}
+
 // LoadMachineByName returns a machine config based on the vm name and provider
 func LoadMachineByName(name string, dirs *define.MachineDirs) (*MachineConfig, error) {
 	fullPath, err := dirs.ConfigDir.AppendToNewVMFile(name+".json", nil)

--- a/vendor/github.com/containers/podman/v5/pkg/machine/wsl/declares.go
+++ b/vendor/github.com/containers/podman/v5/pkg/machine/wsl/declares.go
@@ -48,6 +48,10 @@ ln -fs /usr/lib/systemd/system/podman.socket /etc/systemd/system/sockets.target.
 const sudoers = `%wheel        ALL=(ALL)       NOPASSWD: ALL
 `
 
+const bootstrapSystemdConfig = `#!/bin/bash
+nohup bash -c 'while true; do sleep 60; done' >/dev/null 2>&1 &
+`
+
 const bootstrap = `#!/bin/bash
 ps -ef | grep -v grep | grep -q systemd && exit 0
 nohup unshare --kill-child --fork --pid --mount --mount-proc --propagation shared /lib/systemd/systemd >/dev/null 2>&1 &
@@ -62,6 +66,8 @@ or type exit. This also means to log out you need to exit twice.
 `
 
 const sysdpid = "SYSDPID=`ps -eo cmd,pid | grep -m 1 ^/lib/systemd/systemd | awk '{print $2}'`"
+
+const sysdpidSystemdConfig = "SYSDPID=`grep -q systemd /proc/1/comm && echo '1' || echo '0'`"
 
 const profile = sysdpid + `
 if [ ! -z "$SYSDPID" ] && [ "$SYSDPID" != "1" ]; then
@@ -93,6 +99,10 @@ fi
 
 const wslConf = `[user]
 default=[USER]
+`
+
+const wslSystemdConf = `[boot]
+systemd=true
 `
 
 const wslConfUserNet = `

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -285,8 +285,8 @@ github.com/containers/image/v5/transports
 github.com/containers/image/v5/transports/alltransports
 github.com/containers/image/v5/types
 github.com/containers/image/v5/version
-# github.com/containers/libhvee v0.10.0
-## explicit; go 1.22.8
+# github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5
+## explicit; go 1.23.3
 github.com/containers/libhvee/pkg/hypervctl
 github.com/containers/libhvee/pkg/kvp/ginsu
 github.com/containers/libhvee/pkg/wmiext
@@ -314,7 +314,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250612142329-e5103c59144d
+# github.com/containers/podman/v5 v5.3.1 => github.com/cfergeau/podman/v5 v5.0.0-20250723135928-052bdcf53a71
 ## explicit; go 1.23.3
 github.com/containers/podman/v5/cmd/podman/parse
 github.com/containers/podman/v5/cmd/podman/registry
@@ -1293,5 +1293,5 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v1.0.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250612142329-e5103c59144d
+# github.com/containers/podman/v5 => github.com/cfergeau/podman/v5 v5.0.0-20250723135928-052bdcf53a71
 # github.com/crc-org/machine => github.com/cfergeau/machine v0.0.0-20241127155529-1b8b9b8d1078


### PR DESCRIPTION
this commit add support to hyperv.
It allows to create/start/ssh/stop a hyperv VM.
Under the hood it uses cloud-init to configure the hyperv VM and uses system-mode networking.

It must be used with the new `--provider` flag (https://github.com/crc-org/macadam/pull/194).
An example with Fedora cloud image `https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Azure-42-1.1.x86_64.vhdfixed.xz` extracted locally as .vhd

```
macadam init <path>/Fedora-Cloud-Base-Azure-42-1.1.x86_64.vhd --provider hyperv
macadam start --provider hyperv
macadam ssh --provider hyperv
macadam stop --provider hyperv
macadam rm -f --provider hyperv
```

## Summary by Sourcery

Add support for HyperV as a machine provider with corresponding SSH handling and preflight checks, and update dependencies to align with testing forks.

New Features:
- Support HyperV VM lifecycle operations (create, start, SSH, stop)

Enhancements:
- Enable HyperV provider in preflight compatibility checks
- Use the VM’s IP address when SSHing into HyperV VMs

Build:
- Bump libhvee version in go.mod
- Update module replacements for podman and machine to testing forks

## Summary by Sourcery

Enable HyperV as a new VM provider with full lifecycle support and enhanced SSH handling.

New Features:
- Add support for HyperV provider enabling VM creation, start, SSH, and stop operations

Enhancements:
- Include HyperV in provider compatibility checks by removing it from the unsupported list
- Use the VM’s IP address for SSH connections with a fallback to localhost

Build:
- Bump libhvee dependency version
- Update podman and machine module replacements to testing forks

Chores:
- Vendor updated modules to integrate HyperV stubber and related dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Hyper-V as a VM provider on Windows, alongside existing providers.
  * Machines now track and use their own IP address for SSH and networking, enabling connections beyond localhost.
  * Optional DVD drive support added to virtual machines for cloud-init scenarios.
  * Enhanced cloud-init and systemd configuration options for WSL and Hyper-V providers.

* **Improvements**
  * SSH and networking logic now explicitly use the machine's resolved address, improving reliability and flexibility.
  * Networking setup and readiness checks are now address-aware and adapt to user-mode networking settings.
  * Expanded provider and network configuration options for better compatibility and setup flows.
  * Refined ignition builder usage to avoid processing when not applicable.
  * Conditional handling of user-mode networking and cloud-init for improved VM lifecycle management.

* **Bug Fixes**
  * Prevented errors when ignition builders are not present during VM creation.
  * Fixed scoping and conditional execution issues in WSL stop logic.
  * Improved error handling and conditional logic for VM networking and readiness.

* **Chores**
  * Updated dependencies to newer versions for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->