### PR TITLE
Add provider flag support to ssh and inspect actions

### DIFF
--- a/cmd/macadam/inspect.go
+++ b/cmd/macadam/inspect.go
@@ -10,9 +10,9 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/utils"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
-	providerpkg "github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/crc-org/macadam/cmd/macadam/registry"
+	provider2 "github.com/crc-org/macadam/pkg/machinedriver/provider"
 	"github.com/spf13/cobra"
 )
 
@@ -51,11 +51,11 @@ func inspect(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
-	provider, err := providerpkg.Get()
+	vmProvider, err := provider2.GetProviderOrDefault(provider)
 	if err != nil {
-		return nil
+		return err
 	}
-	dirs, err := env.GetMachineDirs(provider.VMType())
+	dirs, err := env.GetMachineDirs(vmProvider.VMType())
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		state, err := provider.State(mc, false)
+		state, err := vmProvider.State(mc, false)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 			Resources:          mc.Resources,
 			SSHConfig:          mc.SSH,
 			State:              state,
-			UserModeNetworking: provider.UserModeNetworkEnabled(mc),
+			UserModeNetworking: vmProvider.UserModeNetworkEnabled(mc),
 		}
 		if ii.LastUp.IsZero() {
 			ii.LastUp = nil

--- a/cmd/macadam/ssh.go
+++ b/cmd/macadam/ssh.go
@@ -11,9 +11,9 @@ import (
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v5/cmd/podman/utils"
 	"github.com/containers/podman/v5/pkg/machine"
-	providerpkg "github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/crc-org/macadam/cmd/macadam/registry"
+	provider2 "github.com/crc-org/macadam/pkg/machinedriver/provider"
 	"github.com/spf13/cobra"
 )
 
@@ -54,11 +54,11 @@ func ssh(cmd *cobra.Command, args []string) error {
 		validVM bool
 	)
 
-	provider, err := providerpkg.Get()
+	vmProvider, err := provider2.GetProviderOrDefault(provider)
 	if err != nil {
-		return nil
+		return err
 	}
-	dirs, err := env.GetMachineDirs(provider.VMType())
+	dirs, err := env.GetMachineDirs(vmProvider.VMType())
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	state, err := provider.State(mc, false)
+	state, err := vmProvider.State(mc, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/machinedriver/crcimageprovider.go
+++ b/pkg/machinedriver/crcimageprovider.go
@@ -35,12 +35,10 @@ var (
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 )
 
-func NewCrcImagePuller(vmType define.VMType) (*CrcImagePuller, error) {
-	crcImage := CrcImagePuller{
+func NewCrcImagePuller(vmType define.VMType) *CrcImagePuller {
+	return &CrcImagePuller{
 		vmType: vmType,
 	}
-
-	return &crcImage, nil
 }
 
 /* TODO: Might be better to pass an actual URI and to strip the "file://" part from it */

--- a/pkg/machinedriver/driver.go
+++ b/pkg/machinedriver/driver.go
@@ -207,10 +207,7 @@ func (d *Driver) Create() error {
 	*/
 
 	initOpts := d.initOpts()
-	crcPuller, err := NewCrcImagePuller(d.vmProvider.VMType())
-	if err != nil {
-		return nil
-	}
+	crcPuller := NewCrcImagePuller(d.vmProvider.VMType())
 	crcPuller.SetSourceURI(d.ImageSourcePath)
 	initOpts.ImagePuller = crcPuller
 


### PR DESCRIPTION
Not sure what happened but i did not push the changes for these 2 actions in https://github.com/crc-org/macadam/pull/194

This patch adds support for the --provider flag to the ssh and inspect actions. All other actions were updated by https://github.com/crc-org/macadam/commit/fb5ad86204e02e2dc20f1d7feb8522e820938603

## Summary by Sourcery

Enable --provider flag support in ssh and inspect commands by switching provider resolution to macadam’s machinedriver package

Enhancements:
- Switch ssh and inspect to use GetProviderOrDefault for provider selection
- Update provider-dependent calls (VMType, State, UserModeNetworking) to use the new vmProvider implementation from macadam

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal provider package usage to improve maintainability with no impact on user-facing functionality.
  * Simplified image puller initialization to streamline machine driver operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->