### PR TITLE
Add krunkit support

### DIFF
--- a/pkg/imagepullers/noop.go
+++ b/pkg/imagepullers/noop.go
@@ -38,12 +38,12 @@ func (puller *NoopImagePuller) SetSourceURI(sourcePath string) {
 
 func imageExtension(vmType define.VMType, sourceURI string) string {
 	switch vmType {
-	case define.AppleHvVirt:
-		return ".raw"
 	case define.WSLVirt:
 		return ".tar.gz"
-	default:
+	case define.QemuVirt, define.HyperVVirt:
 		return filepath.Ext(sourceURI)
+	default:
+		return "." + vmType.ImageFormat().Kind()
 	}
 }
 

--- a/pkg/imagepullers/noop.go
+++ b/pkg/imagepullers/noop.go
@@ -93,10 +93,12 @@ func doCopyFile(src, dest string, vmType define.VMType) error {
 	}
 	defer destF.Close()
 
-	if vmType == define.AppleHvVirt {
+	switch vmType {
+	case define.AppleHvVirt, define.LibKrun:
 		return copyFileMac(srcF, destF)
+	default:
+		return copyFile(srcF, destF)
 	}
-	return copyFile(srcF, destF)
 }
 
 func copyFileMac(src, dest *os.File) error {

--- a/pkg/machinedriver/provider/platform_darwin.go
+++ b/pkg/machinedriver/provider/platform_darwin.go
@@ -6,16 +6,20 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/applehv"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/sirupsen/logrus"
 )
 
-const appleHV = "applehv"
+var defaultProvider = define.AppleHvVirt
 
 func GetProviderOrDefault(name string) (vmconfigs.VMProvider, error) {
-	if name == "" {
-		name = define.AppleHvVirt.String()
+	resolvedVMType, err := define.ParseVMType(name, defaultProvider)
+	if err != nil {
+		return nil, err
 	}
-	switch name {
-	case appleHV:
+
+	logrus.Debugf("Using macadam with `%s` virtualization provider", resolvedVMType.String())
+	switch resolvedVMType {
+	case define.AppleHvVirt:
 		return new(applehv.AppleHVStubber), nil
 	default:
 		return nil, fmt.Errorf("unknown provider `%s`. Valid providers are: %v", name, GetProviders())
@@ -23,9 +27,9 @@ func GetProviderOrDefault(name string) (vmconfigs.VMProvider, error) {
 }
 
 func GetProviders() []string {
-	return []string{appleHV}
+	return []string{define.AppleHvVirt.String()}
 }
 
 func GetDefaultProvider() string {
-	return appleHV
+	return defaultProvider.String()
 }

--- a/pkg/machinedriver/provider/platform_darwin.go
+++ b/pkg/machinedriver/provider/platform_darwin.go
@@ -1,10 +1,13 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
+	"runtime"
 
 	"github.com/containers/podman/v5/pkg/machine/applehv"
 	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/libkrun"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 )
@@ -21,13 +24,22 @@ func GetProviderOrDefault(name string) (vmconfigs.VMProvider, error) {
 	switch resolvedVMType {
 	case define.AppleHvVirt:
 		return new(applehv.AppleHVStubber), nil
+	case define.LibKrun:
+		if runtime.GOARCH == "amd64" {
+			return nil, errors.New("libkrun is not supported on Intel based machines. Please revert to the applehv provider")
+		}
+		return new(libkrun.LibKrunStubber), nil
 	default:
 		return nil, fmt.Errorf("unknown provider `%s`. Valid providers are: %v", name, GetProviders())
 	}
 }
 
 func GetProviders() []string {
-	return []string{define.AppleHvVirt.String()}
+	configs := []string{define.AppleHvVirt.String()}
+	if runtime.GOARCH == "arm64" {
+		configs = append(configs, define.LibKrun.String())
+	}
+	return configs
 }
 
 func GetDefaultProvider() string {

--- a/pkg/machinedriver/provider/platform_unix.go
+++ b/pkg/machinedriver/provider/platform_unix.go
@@ -8,16 +8,20 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 	qemuPkg "github.com/containers/podman/v5/pkg/machine/qemu"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/sirupsen/logrus"
 )
 
-const qemu = "qemu"
+var defaultProvider = define.QemuVirt
 
 func GetProviderOrDefault(name string) (vmconfigs.VMProvider, error) {
-	if name == "" {
-		name = define.QemuVirt.String()
+	resolvedVMType, err := define.ParseVMType(name, defaultProvider)
+	if err != nil {
+		return nil, err
 	}
-	switch name {
-	case qemu:
+
+	logrus.Debugf("Using macadam with `%s` virtualization provider", resolvedVMType.String())
+	switch resolvedVMType {
+	case define.QemuVirt:
 		return new(qemuPkg.QEMUStubber), nil
 	default:
 		return nil, fmt.Errorf("unknown provider `%s`. Valid providers are: %v", name, GetProviders())
@@ -25,9 +29,9 @@ func GetProviderOrDefault(name string) (vmconfigs.VMProvider, error) {
 }
 
 func GetProviders() []string {
-	return []string{qemu}
+	return []string{define.QemuVirt.String()}
 }
 
 func GetDefaultProvider() string {
-	return qemu
+	return defaultProvider.String()
 }


### PR DESCRIPTION
This goes with https://github.com/cfergeau/podman/pull/22

## Summary by Sourcery

Add LibKrun/krunkit support on macOS arm64, refactor cross-platform provider resolution and default handling, enhance image puller behavior and preflight checks, and update dependencies.

New Features:
- Introduce LibKrun virtualization stubber on arm64 macOS with krunkit support
- Add krunkit binary availability check in preflight for the LibKrun provider

Enhancements:
- Refactor provider resolution to use define.ParseVMType and defaultProvider across macOS, Linux, and Windows
- Replace hardcoded provider strings with dynamic lists based on runtime architecture
- Add debug logging for the selected virtualization provider
- Update NoopImagePuller to handle LibKrun and AppleHv raw images and proper file copying
- Adjust preflight checks to target vfkit only for AppleHvVirt and expand supported providers error messaging to include krunkit

Build:
- Bump containers/libhvee dependency and update the Podman replace directive in go.mod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the LibKrun virtualization provider on ARM64 platforms.
  * Introduced checks for the presence and version of the "krunkit" binary when using LibKrun.

* **Bug Fixes**
  * Improved error handling and provider resolution for virtualization providers across macOS, Linux, and Windows.

* **Refactor**
  * Enhanced logic for determining image file extensions and file copying methods based on virtualization provider.
  * Unified provider selection and defaulting with improved type safety and logging.
  * Updated preflight checks to better handle provider-specific requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->