### PR TITLE
use extension of source image on WSL

### DIFF
--- a/pkg/imagepullers/noop.go
+++ b/pkg/imagepullers/noop.go
@@ -39,6 +39,10 @@ func (puller *NoopImagePuller) SetSourceURI(sourcePath string) {
 func imageExtension(vmType define.VMType, sourceURI string) string {
 	switch vmType {
 	case define.WSLVirt:
+		ext := filepath.Ext(sourceURI)
+		if ext == ".wsl" {
+			return ".wsl"
+		}
 		return ".tar.gz"
 	case define.QemuVirt, define.HyperVVirt:
 		return filepath.Ext(sourceURI)


### PR DESCRIPTION
when testing #209 using the main branch i saw that macadam already works fine with .WSL format images. When we copy the image in `.tar.gz` we do not break anything - they are compatible. However, keeping the exact extension should be the correct way to handle it. 

it resolves #209 