### PR TITLE
add check on image format/hypervisor

### DIFF
--- a/pkg/imagepullers/noop.go
+++ b/pkg/imagepullers/noop.go
@@ -41,7 +41,12 @@ func (puller *NoopImagePuller) LocalPath() (*define.VMFile, error) {
 		return nil, err
 	}
 
-	vmFile, err := dirs.DataDir.AppendToNewVMFile(fmt.Sprintf("%s-%s%s", puller.machineName, puller.vmType.String(), imageExtension(puller.vmType, puller.sourceURI)), nil)
+	imageExt, err := imageExtension(puller.vmType, puller.sourceURI)
+	if err != nil {
+		return nil, err
+	}
+
+	vmFile, err := dirs.DataDir.AppendToNewVMFile(fmt.Sprintf("%s-%s%s", puller.machineName, puller.vmType.String(), imageExt), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imagepullers/noop_darwin.go
+++ b/pkg/imagepullers/noop_darwin.go
@@ -5,6 +5,8 @@ package imagepullers
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
 
@@ -15,8 +17,13 @@ import (
 	"github.com/lima-vm/go-qcow2reader/image/raw"
 )
 
-func imageExtension(vmType define.VMType, _ string) string {
-	return "." + vmType.ImageFormat().Kind()
+func imageExtension(_ define.VMType, sourceURI string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(sourceURI))
+	if ext != ".qcow2" && ext != ".raw" {
+		return "", fmt.Errorf("unsupported image extension %s; supported formats are .qcow2 and .raw", ext)
+	}
+	// Destination for AppleHvVirt/LibKrun is raw; copyFileMac converts qcow2 -> raw.
+	return ".raw", nil
 }
 
 func doCopyFile(src *os.File, dest string) error {

--- a/pkg/imagepullers/noop_unix.go
+++ b/pkg/imagepullers/noop_unix.go
@@ -3,14 +3,20 @@
 package imagepullers
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
 )
 
-func imageExtension(_ define.VMType, sourceURI string) string {
-	return filepath.Ext(sourceURI)
+func imageExtension(_ define.VMType, sourceURI string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(sourceURI))
+	if ext != ".qcow2" && ext != ".raw" {
+		return "", fmt.Errorf("unsupported image extension %s; supported formats are .qcow2 and .raw", ext)
+	}
+	return ext, nil
 }
 
 func doCopyFile(src *os.File, dest string) error {


### PR DESCRIPTION
it adds a check to the NoopImagePuller to verify the image extension is
supported by the hypervisor before copying the image. If it fails the user
is prompt with a descriptive error message.

The image formats supported are:
- WSL: .wsl, .tar.gz
- Hyperv: .vhdx, .vhd
- Qemu/Applehv/Libkrun: .raw, .qcow2

it resolves #202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear, descriptive errors for unsupported image extensions per VM type, preventing silent defaults.
  * Image import and local-path logic now fail explicitly on invalid or ambiguous extensions to avoid incorrect filenames.

* **Refactor**
  * Unified extension validation across platforms with consistent error messaging and supported-format lists.
  * Callers now handle explicit validation outcomes rather than implicit defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->