### PR TITLE
skip gvproxy check on hyperv

### DIFF
--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -31,7 +31,7 @@ func RunPreflights(provider vmconfigs.VMProvider) error {
 // macadam/podman needs a gvproxy version which supports the --services
 // argument
 func checkGvproxyVersion(provider vmconfigs.VMProvider) error {
-	if provider.VMType() == define.WSLVirt {
+	if provider.VMType() == define.WSLVirt || provider.VMType() == define.HyperVVirt {
 		return nil
 	}
 	if err := checkBinaryArg(machine.ForwarderBinaryName, "-services"); err != nil {


### PR DESCRIPTION
hyperv only works using system mode networking for the moment. There is no need to check if gvproxy is installed and support the -services arg

it resolves #218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by exempting an additional VM type from the gvproxy version check, reducing unnecessary version errors for users with certain VM configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->