### PR TITLE
update runtimeDir to prevent collision between different providers

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -33,8 +33,8 @@ func SetupEnvironment(provider vmconfigs.VMProvider) error {
 	}
 
 	// set the directory to be used when calculating runtime path
-	// run -> <runHome>/macadam (runHome changes based on the OS used e.g. runHome == /run)
-	err = os.Setenv("PODMAN_RUNTIME_DIR", "macadam")
+	// run -> <runHome>/macadam/<provider> (runHome changes based on the OS used e.g. runHome == /run)
+	err = os.Setenv("PODMAN_RUNTIME_DIR", filepath.Join("macadam", provider.VMType().String()))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
the current way of storing runtime files is error-prone as two machines having the same name but belonging to two different providers could save the same file on the same path.

This commit adds a provider subfolder path so two different providers do not share the same runtime directory.

As discussed in https://github.com/cfergeau/podman/pull/26