### PR TITLE
env: Store connection file in XDG_CONFIG_HOME

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -17,7 +17,7 @@ func SetupEnvironment(provider vmconfigs.VMProvider) error {
 		return err
 	}
 
-	connsFile := filepath.Join(filepath.Dir(path), "macadam", connectionsFile)
+	connsFile := filepath.Join(path, "macadam", connectionsFile)
 	// set the path used for storing connection of macadam vms
 	err = os.Setenv("PODMAN_CONNECTIONS_CONF", connsFile)
 	if err != nil {


### PR DESCRIPTION
The connection file is currently stored in
~/macadam/macadam-connections.json.

Looking at the code and at where podman stores it
(~/.config/containers/), the intent seems to have been to put it in
`~/.config/macadam/macadam-connections.json`.

This commit removes a `filepath.Dir` call to achieve this.

This fixes https://github.com/crc-org/macadam/issues/181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the location of the Podman connections configuration to reside directly under the user’s config directory. This ensures the application reads the expected file, improves consistency across environments, and reduces issues on systems like WSL. Existing data and runtime environment variables remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->