### PR TITLE
Separate binary artifacts when cross built

### DIFF
--- a/.github/workflows/macadam.yml
+++ b/.github/workflows/macadam.yml
@@ -35,12 +35,24 @@ jobs:
 
       - name: Build
         run: make cross
-      - name: Upload macadam artifact
+      - name: Upload macadam artifact (windows)
         if: matrix.go == 'stable'
         uses: actions/upload-artifact@v4
         with:
-          name: macadam binaries
-          path: "./bin/*"
+          name: macadam windows binaries
+          path: "./bin/*windows*"
+      - name: Upload macadam artifact (linux)
+        if: matrix.go == 'stable'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macadam linux binaries
+          path: "./bin/*linux*"
+      - name: Upload macadam artifact (macos)
+        if: matrix.go == 'stable'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macadam macos binaries
+          path: "./bin/*darwin*"          
 
 
   test:
@@ -79,7 +91,7 @@ jobs:
       - name: Download binary artifact
         uses: actions/download-artifact@v5
         with:
-          name: macadam binaries
+          name: macadam linux binaries
           path: ./bin
       - name: Setup qemu (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Related to #232 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to upload OS-specific binaries (Windows, Linux, macOS) for clearer distribution and troubleshooting.
  * Removed the generic combined binary artifact to reduce ambiguity in downloads.
  * Adjusted end-to-end tests to use the Linux-specific binary artifact.
  * Improves release reliability and makes artifact selection more straightforward for platform-specific needs.
  * No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->