### PR TITLE
gha: Separate binary artifacts when cross built

### DIFF
--- a/.github/workflows/macadam.yml
+++ b/.github/workflows/macadam.yml
@@ -35,12 +35,24 @@ jobs:
 
       - name: Build
         run: make cross
-      - name: Upload macadam artifact
+      - name: Upload macadam artifact (windows)
         if: matrix.go == 'stable'
         uses: actions/upload-artifact@v4
         with:
-          name: macadam binaries
-          path: "./bin/*"
+          name: macadam windows binaries
+          path: "./bin/*windows*"
+      - name: Upload macadam artifact (linux)
+        if: matrix.go == 'stable'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macadam linux binaries
+          path: "./bin/*linux*"
+      - name: Upload macadam artifact (macos)
+        if: matrix.go == 'stable'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macadam macos binaries
+          path: "./bin/*darwin*"
 
 
   test:
@@ -79,7 +91,7 @@ jobs:
       - name: Download binary artifact
         uses: actions/download-artifact@v5
         with:
-          name: macadam binaries
+          name: macadam linux binaries
           path: ./bin
       - name: Setup qemu (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
If these binaries are used in GH workflows, they should effectively be as small as possible.
This will also make them easier to download for people with suboptimal network connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release artifacts are now published per operating system (Windows, macOS, Linux), improving clarity for platform-specific downloads.
  * End-to-end automation updated to fetch the Linux artifact during testing.
  * No changes to application behavior or supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->